### PR TITLE
Dockerfile: do not set LIMITS_FILE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,4 @@ RUN chown limitador:limitador limitador-server
 
 USER limitador
 
-ENV LIMITS_FILE=/home/limitador/limits.yaml
-
 CMD ["limitador-server"]


### PR DESCRIPTION
Limitador shouldn't load any limits by default. This was done for testing purposes and I forgot to change it.