### PR TITLE
Revert "Merge pull request #12 from 3scale-labs/update-redis-n-tokio"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,13 +7,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78d1833b3838dbe990df0f1f87baf640cf6146e898166afe401839d1b001e570"
 dependencies = [
  "bitflags",
- "bytes 0.5.6",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project 0.4.27",
- "tokio 0.2.24",
- "tokio-util 0.3.1",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -47,10 +47,10 @@ dependencies = [
  "actix-service",
  "actix-threadpool",
  "actix-utils",
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "brotli2",
- "bytes 0.5.6",
+ "bytes",
  "cookie",
  "copyless",
  "derive_more",
@@ -61,7 +61,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "fxhash",
- "h2 0.2.7",
+ "h2",
  "http",
  "httparse",
  "indexmap",
@@ -71,8 +71,8 @@ dependencies = [
  "log",
  "mime",
  "percent-encoding",
- "pin-project 1.0.4",
- "rand 0.7.3",
+ "pin-project 1.0.2",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "actix-macros"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
+checksum = "a60f9ba7c4e6df97f3aacb14bb5c0cd7d98a49dcbaed0d7f292912ad9a6a3ed2"
 dependencies = [
  "quote",
  "syn",
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8be584b3b6c705a18eabc11c4059cf83b255bdd8511673d1d569f4ce40c69de"
+checksum = "bbd1f7dbda1645bf7da33554db60891755f6c01c1b2169e2f4c492098d30c235"
 dependencies = [
  "bytestring",
  "http",
@@ -117,7 +117,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "mio 0.6.23",
+ "mio",
  "mio-uds",
  "num_cpus",
  "slab",
@@ -201,7 +201,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "bitflags",
- "bytes 0.5.6",
+ "bytes",
  "either",
  "futures-channel",
  "futures-sink",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "3.3.2"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e641d4a172e7faa0862241a20ff4f1f5ab0ab7c279f00c2d4587b77483477b86"
+checksum = "7d6d0a6ae7ff7290372b3f636b9fc38b76dfbfc395187ce21e5b95471f7ccab9"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -230,7 +230,7 @@ dependencies = [
  "actix-utils",
  "actix-web-codegen",
  "awc",
- "bytes 0.5.6",
+ "bytes",
  "derive_more",
  "encoding_rs",
  "futures-channel",
@@ -239,7 +239,7 @@ dependencies = [
  "fxhash",
  "log",
  "mime",
- "pin-project 1.0.4",
+ "pin-project 1.0.2",
  "regex",
  "serde",
  "serde_json",
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
  "gimli",
 ]
@@ -287,21 +287,115 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
 name = "arc-swap"
-version = "1.2.0"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+
+[[package]]
+name = "async-channel"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log",
+ "nb-connect",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
+dependencies = [
+ "async-global-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite 0.1.11",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
 
 [[package]]
 name = "async-stream"
-version = "0.3.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -309,14 +403,20 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
@@ -328,6 +428,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -356,15 +462,15 @@ dependencies = [
  "actix-http",
  "actix-rt",
  "actix-service",
- "base64",
- "bytes 0.5.6",
+ "base64 0.13.0",
+ "bytes",
  "cfg-if 1.0.0",
  "derive_more",
  "futures-core",
  "log",
  "mime",
  "percent-encoding",
- "rand 0.7.3",
+ "rand",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -392,6 +498,12 @@ checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -409,6 +521,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
 ]
 
 [[package]]
@@ -451,9 +577,9 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
@@ -462,19 +588,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "bytes"
-version = "1.0.1"
+name = "bytestring"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "fc7c05fa5172da78a62d9949d662d2ac89d4cc7355d7b49adee5163f1fb3f363"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
-name = "bytestring"
-version = "1.0.0"
+name = "cache-padded"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
-dependencies = [
- "bytes 1.0.1",
-]
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cast"
@@ -487,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
 
 [[package]]
 name = "cfg-if"
@@ -515,23 +641,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.5.2"
+name = "cloudabi"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4369b5e4c0cddf64ad8981c0111e7df4f7078f4d6ba98fb31f2e17c4c57b7e"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
- "bytes 1.0.1",
+ "bitflags",
+]
+
+[[package]]
+name = "combine"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9417a0c314565e2abffaece67e95a8cb51f9238cd39f3764d9dfdf09e72b20c"
+dependencies = [
+ "bytes",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.4",
- "tokio 1.0.2",
+ "pin-project-lite 0.1.11",
+ "tokio",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
 name = "const_fn"
-version = "0.4.5"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "cookie"
@@ -576,7 +720,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -598,7 +742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.9.0",
 ]
 
 [[package]]
@@ -697,9 +841,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dtoa"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
@@ -739,6 +883,21 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -793,9 +952,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -808,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -818,15 +977,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -835,15 +994,30 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+
+[[package]]
+name = "futures-lite"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite 0.1.11",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -853,24 +1027,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
+checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -879,7 +1053,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project 1.0.2",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -907,24 +1081,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.10.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -934,12 +1097,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "h2"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -947,37 +1123,17 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.24",
- "tokio-util 0.3.1",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
-dependencies = [
- "bytes 1.0.1",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 1.0.2",
- "tokio-util 0.6.1",
+ "tokio",
+ "tokio-util",
  "tracing",
  "tracing-futures",
 ]
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
 name = "hashbrown"
@@ -987,18 +1143,18 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -1016,22 +1172,22 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "http",
 ]
 
@@ -1049,29 +1205,29 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.14.2"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.0",
+ "h2",
  "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.4",
+ "pin-project 1.0.2",
  "socket2",
- "tokio 1.0.2",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1090,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1130,6 +1286,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
@@ -1139,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
@@ -1163,6 +1328,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,9 +1350,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "limitador"
@@ -1192,13 +1366,13 @@ dependencies = [
  "paste",
  "prometheus",
  "r2d2",
- "rand 0.8.2",
+ "rand",
  "redis",
  "serde",
  "serde_json",
  "serial_test",
  "thiserror",
- "tokio 1.0.2",
+ "tokio",
  "ttl_cache",
 ]
 
@@ -1216,16 +1390,16 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_yaml",
- "tokio 1.0.2",
+ "tokio",
  "tonic",
  "tonic-build",
 ]
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "lock_api"
@@ -1239,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.13"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -1300,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -1318,15 +1492,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.7.7"
+name = "mio-named-pipes"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "libc",
  "log",
+ "mio",
  "miow 0.3.6",
- "ntapi",
  "winapi 0.3.9",
 ]
 
@@ -1338,7 +1511,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio 0.6.23",
+ "mio",
 ]
 
 [[package]]
@@ -1370,22 +1543,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
-name = "net2"
-version = "0.2.37"
+name = "nb-connect"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
 dependencies = [
- "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.3.6"
+name = "net2"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -1439,13 +1613,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cc445ec12c9ce0ba673cfda392c4aaea27bc5e26fa3e7bd2689386208f00f7b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.9.0",
  "once_cell",
  "paperclip-actix",
  "paperclip-core",
  "paperclip-macros",
  "parking_lot",
- "semver 0.11.0",
+ "semver 0.10.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1481,7 +1655,7 @@ dependencies = [
  "once_cell",
  "paperclip-macros",
  "parking_lot",
- "pin-project 1.0.4",
+ "pin-project 1.0.2",
  "regex",
  "serde",
  "serde_json",
@@ -1508,6 +1682,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,38 +1700,30 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
+ "cloudabi",
  "instant",
  "libc",
- "redox_syscall 0.1.57",
+ "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+checksum = "7151b083b0664ed58ed669fcdd92f01c3d2fdbf10af4931a301474950b52bfa9"
 
 [[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
 
 [[package]]
 name = "petgraph"
@@ -1574,11 +1746,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.4"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.4",
+ "pin-project-internal 1.0.2",
 ]
 
 [[package]]
@@ -1594,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.4"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1611,9 +1783,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -1631,6 +1803,19 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "polling"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "wepoll-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1671,9 +1856,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -1686,11 +1871,11 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8425533e7122f0c3cc7a37e6244b16ad3a2cc32ae7ac6276e2a75da0d9c200d"
+checksum = "30d70cf4412832bcac9cffe27906f4a66e450d323525e977168c70d1b36120ae"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "fnv",
  "lazy_static",
  "parking_lot",
@@ -1701,23 +1886,23 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "heck",
- "itertools",
+ "itertools 0.8.2",
  "log",
  "multimap",
  "petgraph",
@@ -1729,12 +1914,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.8.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1742,19 +1927,19 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "prost",
 ]
 
 [[package]]
 name = "protobuf"
-version = "2.20.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86473d5f16580f10b131a0bf0afb68f8e029d1835d33a00f37281b05694e5312"
+checksum = "da78e04bc0e40f36df43ecc6575e4f4b180e8156c4efd73f13d5619479b05696"
 
 [[package]]
 name = "quick-error"
@@ -1764,9 +1949,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
@@ -1788,23 +1973,12 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.16",
+ "getrandom",
  "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
-dependencies = [
- "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.1",
- "rand_hc 0.3.0",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+ "rand_pcg",
 ]
 
 [[package]]
@@ -1814,17 +1988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1833,16 +1997,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
-dependencies = [
- "getrandom 0.2.2",
+ "getrandom",
 ]
 
 [[package]]
@@ -1851,16 +2006,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.0"
+name = "rand_pcg"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1890,23 +2045,24 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.19.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a6ddfecac9391fed21cce10e83c65fa4abafd77df05c98b1c647c65374ce9b3"
+checksum = "95357caf2640abc54651b93c98a8df4fe1ccbf44b8e601ccdf43d5c1451f29ac"
 dependencies = [
  "arc-swap",
+ "async-std",
  "async-trait",
- "bytes 1.0.1",
+ "bytes",
  "combine",
  "dtoa",
  "futures",
  "futures-util",
  "itoa",
  "percent-encoding",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.1.11",
  "sha1",
- "tokio 1.0.2",
- "tokio-util 0.6.1",
+ "tokio",
+ "tokio-util",
  "url",
 ]
 
@@ -1917,19 +2073,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1948,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -2022,16 +2169,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser",
 ]
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -2041,19 +2188,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
-
-[[package]]
 name = "serde"
-version = "1.0.120"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
@@ -2070,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.120"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2081,9 +2219,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -2104,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.15"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "971be8f6e4d4a47163b405a3df70d14359186f9ab0f3a3ec37df144ca1ce089f"
+checksum = "f7baae0a99f1a324984bcdc5f0718384c1f69775f1c7eec8b859b71b443e3fd7"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -2157,9 +2295,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
  "libc",
 ]
@@ -2172,26 +2310,27 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
+ "redox_syscall",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "standback"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66a8cff4fa24853fdf6b51f75c6d7f8206d7c75cab4e467bcd7f25c2b1febe0"
+checksum = "cf906c8b8fc3f6ecd1046e01da1d8ddec83e48c8b08b84dcc02b585a6bedf5a8"
 dependencies = [
  "version_check",
 ]
@@ -2265,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2276,14 +2415,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "libc",
- "rand 0.8.2",
- "redox_syscall 0.2.4",
+ "rand",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2308,18 +2447,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2328,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
 ]
@@ -2346,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.24"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273d3ed44dca264b0d6b3665e8d48fb515042d42466fad93d2a45b90ec4058f7"
+checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
 dependencies = [
  "const_fn",
  "libc",
@@ -2384,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
+checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
 dependencies = [
  "serde",
  "serde_json",
@@ -2409,64 +2548,37 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
+ "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "libc",
  "memchr",
- "mio 0.6.23",
+ "mio",
+ "mio-named-pipes",
  "mio-uds",
+ "num_cpus",
  "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec"
-dependencies = [
- "autocfg",
- "bytes 1.0.1",
- "libc",
- "memchr",
- "mio 0.7.7",
- "num_cpus",
- "once_cell",
- "parking_lot",
- "pin-project-lite 0.2.4",
- "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.0.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
-dependencies = [
- "futures-core",
- "pin-project-lite 0.2.4",
- "tokio 1.0.2",
 ]
 
 [[package]]
@@ -2475,53 +2587,39 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio 0.2.24",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ae4751faa60b9f96dd8344d74592e5a17c0c9a220413dbc6942d14139bbfcc"
-dependencies = [
- "bytes 1.0.1",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.2.4",
- "tokio 1.0.2",
- "tokio-stream",
+ "tokio",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba8f479158947373b6df40cf48f4779bb25c99ca3c661bd95e0ab1963ad8b0e"
+checksum = "74a5d6e7439ecf910463667080de772a9c7ddf26bc9fb4f3252ac3862e43337d"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
- "bytes 1.0.1",
+ "base64 0.12.3",
+ "bytes",
  "futures-core",
  "futures-util",
- "h2 0.3.0",
  "http",
  "http-body",
  "hyper",
  "percent-encoding",
- "pin-project 1.0.4",
+ "pin-project 0.4.27",
  "prost",
  "prost-derive",
- "tokio 1.0.2",
- "tokio-stream",
- "tokio-util 0.6.1",
+ "tokio",
+ "tokio-util",
  "tower",
+ "tower-balance",
+ "tower-load",
+ "tower-make",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -2529,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e8546fd40d56d28089835c0a81bb396848103b00f888aea42d46eb5974df07"
+checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -2541,34 +2639,181 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855703d368d4c9321ccc1efe1b0fe436c3f20b102b25060707ebe6b4502bdefb"
+checksum = "fd3169017c090b7a28fce80abaad0ab4f5566423677c9331bb320af7e49cfe62"
+dependencies = [
+ "futures-core",
+ "tower-buffer",
+ "tower-discover",
+ "tower-layer",
+ "tower-limit",
+ "tower-load-shed",
+ "tower-retry",
+ "tower-service",
+ "tower-timeout",
+ "tower-util",
+]
+
+[[package]]
+name = "tower-balance"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a792277613b7052448851efcf98a2c433e6f1d01460832dc60bef676bc275d4c"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 1.0.4",
- "rand 0.8.2",
+ "pin-project 0.4.27",
+ "rand",
  "slab",
- "tokio 1.0.2",
- "tokio-stream",
+ "tokio",
+ "tower-discover",
+ "tower-layer",
+ "tower-load",
+ "tower-make",
+ "tower-ready-cache",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-buffer"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
+dependencies = [
+ "futures-core",
+ "pin-project 0.4.27",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
+name = "tower-discover"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
+dependencies = [
+ "futures-core",
+ "pin-project 0.4.27",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
+
+[[package]]
+name = "tower-limit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
+dependencies = [
+ "futures-core",
+ "pin-project 0.4.27",
+ "tokio",
+ "tower-layer",
+ "tower-load",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-load"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
+dependencies = [
+ "futures-core",
+ "log",
+ "pin-project 0.4.27",
+ "tokio",
+ "tower-discover",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-load-shed"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
+dependencies = [
+ "futures-core",
+ "pin-project 0.4.27",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-make"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
+dependencies = [
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-ready-cache"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eabb6620e5481267e2ec832c780b31cad0c15dcb14ed825df5076b26b591e1f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "log",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
+dependencies = [
+ "futures-core",
+ "pin-project 0.4.27",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tower-timeout"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
+dependencies = [
+ "pin-project 0.4.27",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 0.4.27",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"
@@ -2578,7 +2823,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.0",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2626,10 +2871,10 @@ dependencies = [
  "idna",
  "lazy_static",
  "log",
- "rand 0.7.3",
+ "rand",
  "smallvec",
  "thiserror",
- "tokio 0.2.24",
+ "tokio",
  "url",
 ]
 
@@ -2649,7 +2894,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio 0.2.24",
+ "tokio",
  "trust-dns-proto",
 ]
 
@@ -2673,12 +2918,6 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
@@ -2729,10 +2968,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
 name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -2762,12 +3013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wasi"
-version = "0.10.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +3035,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2832,13 +3089,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.0.2"
+name = "wepoll-sys"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
- "thiserror",
 ]
 
 [[package]]
@@ -2911,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 dependencies = [
  "linked-hash-map",
 ]

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -9,17 +9,17 @@ edition = "2018"
 
 [dependencies]
 limitador = { path = "../limitador" }
-tokio = { version = "^1", features = ["full"] }
-tonic = "^0.4"
-prost = "^0.7"
-prost-types = "^0.7"
-serde_yaml = "^0.8"
-log = "^0.4"
-env_logger = "^0.8"
-actix-web = "^3"
-actix-rt = "^1"
-paperclip = { version = "^0.5", features = ["actix"] }
-serde = { version = "^1", features = ["derive"] }
+tokio = { version = "0.2", features = ["full"] }
+tonic = "0.3"
+prost = "0.6"
+prost-types = "0.6"
+serde_yaml = "0.8"
+log = "0.4"
+env_logger = "0.8"
+actix-web = "3"
+actix-rt = "1"
+paperclip = { version = "0.5", features = ["actix"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-tonic-build = "^0.4"
+tonic-build = "0.2"

--- a/limitador-server/src/envoy_rls/protobufs/envoy.config.core.v3.rs
+++ b/limitador-server/src/envoy_rls/protobufs/envoy.config.core.v3.rs
@@ -8,7 +8,7 @@ pub struct SocketOption {
     /// An optional name to give this socket option for debugging, etc.
     /// Uniqueness is not required and no special meaning is assumed.
     #[prost(string, tag = "1")]
-    pub description: ::prost::alloc::string::String,
+    pub description: std::string::String,
     /// Corresponding to the level value passed to setsockopt, such as IPPROTO_TCP
     #[prost(int64, tag = "2")]
     pub level: i64,
@@ -20,9 +20,8 @@ pub struct SocketOption {
     #[prost(enumeration = "socket_option::SocketState", tag = "6")]
     pub state: i32,
     #[prost(oneof = "socket_option::Value", tags = "4, 5")]
-    pub value: ::core::option::Option<socket_option::Value>,
+    pub value: ::std::option::Option<socket_option::Value>,
 }
-/// Nested message and enum types in `SocketOption`.
 pub mod socket_option {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -41,7 +40,7 @@ pub mod socket_option {
         IntValue(i64),
         /// Otherwise it's a byte buffer.
         #[prost(bytes, tag = "5")]
-        BufValue(::prost::alloc::vec::Vec<u8>),
+        BufValue(std::vec::Vec<u8>),
     }
 }
 // [#protodoc-title: Network addresses]
@@ -53,7 +52,7 @@ pub struct Pipe {
     /// Paths starting with '@' will result in an error in environments other than
     /// Linux.
     #[prost(string, tag = "1")]
-    pub path: ::prost::alloc::string::String,
+    pub path: std::string::String,
     /// The mode for the Pipe. Not applicable for abstract sockets.
     #[prost(uint32, tag = "2")]
     pub mode: u32,
@@ -75,14 +74,14 @@ pub struct SocketAddress {
     /// (*STRICT_DNS* or *LOGICAL_DNS* clusters). Address resolution can be customized
     /// via :ref:`resolver_name <envoy_api_field_config.core.v3.SocketAddress.resolver_name>`.
     #[prost(string, tag = "2")]
-    pub address: ::prost::alloc::string::String,
+    pub address: std::string::String,
     /// The name of the custom resolver. This must have been registered with Envoy. If
     /// this is empty, a context dependent default applies. If the address is a concrete
     /// IP address, no resolution will occur. If address is a hostname this
     /// should be set for resolution other than DNS. Specifying a custom resolver with
     /// *STRICT_DNS* or *LOGICAL_DNS* will generate an error at runtime.
     #[prost(string, tag = "5")]
-    pub resolver_name: ::prost::alloc::string::String,
+    pub resolver_name: std::string::String,
     /// When binding to an IPv6 address above, this enables `IPv4 compatibility
     /// <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
     /// allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
@@ -90,9 +89,8 @@ pub struct SocketAddress {
     #[prost(bool, tag = "6")]
     pub ipv4_compat: bool,
     #[prost(oneof = "socket_address::PortSpecifier", tags = "3, 4")]
-    pub port_specifier: ::core::option::Option<socket_address::PortSpecifier>,
+    pub port_specifier: ::std::option::Option<socket_address::PortSpecifier>,
 }
-/// Nested message and enum types in `SocketAddress`.
 pub mod socket_address {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -108,7 +106,7 @@ pub mod socket_address {
         /// <envoy_api_field_config.core.v3.SocketAddress.resolver_name>` is specified below and the
         /// named resolver is capable of named port resolution.
         #[prost(string, tag = "4")]
-        NamedPort(::prost::alloc::string::String),
+        NamedPort(std::string::String),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -117,22 +115,22 @@ pub struct TcpKeepalive {
     /// the connection is dead. Default is to use the OS level configuration (unless
     /// overridden, Linux defaults to 9.)
     #[prost(message, optional, tag = "1")]
-    pub keepalive_probes: ::core::option::Option<u32>,
+    pub keepalive_probes: ::std::option::Option<u32>,
     /// The number of seconds a connection needs to be idle before keep-alive probes
     /// start being sent. Default is to use the OS level configuration (unless
     /// overridden, Linux defaults to 7200s (i.e., 2 hours.)
     #[prost(message, optional, tag = "2")]
-    pub keepalive_time: ::core::option::Option<u32>,
+    pub keepalive_time: ::std::option::Option<u32>,
     /// The number of seconds between keep-alive probes. Default is to use the OS
     /// level configuration (unless overridden, Linux defaults to 75s.)
     #[prost(message, optional, tag = "3")]
-    pub keepalive_interval: ::core::option::Option<u32>,
+    pub keepalive_interval: ::std::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BindConfig {
     /// The address to bind to when creating a socket.
     #[prost(message, optional, tag = "1")]
-    pub source_address: ::core::option::Option<SocketAddress>,
+    pub source_address: ::std::option::Option<SocketAddress>,
     /// Whether to set the *IP_FREEBIND* option when creating the socket. When this
     /// flag is set to true, allows the :ref:`source_address
     /// <envoy_api_field_config.cluster.v3.UpstreamBindConfig.source_address>` to be an IP address
@@ -141,11 +139,11 @@ pub struct BindConfig {
     /// flag is not set (default), the socket is not modified, i.e. the option is
     /// neither enabled nor disabled.
     #[prost(message, optional, tag = "2")]
-    pub freebind: ::core::option::Option<bool>,
+    pub freebind: ::std::option::Option<bool>,
     /// Additional socket options that may not be present in Envoy source code or
     /// precompiled binaries.
     #[prost(message, repeated, tag = "3")]
-    pub socket_options: ::prost::alloc::vec::Vec<SocketOption>,
+    pub socket_options: ::std::vec::Vec<SocketOption>,
 }
 /// Addresses specify either a logical or physical address and port, which are
 /// used to tell Envoy where to bind/listen, connect to upstream and find
@@ -153,9 +151,8 @@ pub struct BindConfig {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Address {
     #[prost(oneof = "address::Address", tags = "1, 2")]
-    pub address: ::core::option::Option<address::Address>,
+    pub address: ::std::option::Option<address::Address>,
 }
-/// Nested message and enum types in `Address`.
 pub mod address {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Address {
@@ -171,10 +168,10 @@ pub mod address {
 pub struct CidrRange {
     /// IPv4 or IPv6 address, e.g. ``192.0.0.0`` or ``2001:db8::``.
     #[prost(string, tag = "1")]
-    pub address_prefix: ::prost::alloc::string::String,
+    pub address_prefix: std::string::String,
     /// Length of prefix, e.g. 0, 32.
     #[prost(message, optional, tag = "2")]
-    pub prefix_len: ::core::option::Option<u32>,
+    pub prefix_len: ::std::option::Option<u32>,
 }
 // [#protodoc-title: Backoff Strategy]
 
@@ -185,14 +182,14 @@ pub struct BackoffStrategy {
     /// be greater than zero and less than or equal to :ref:`max_interval
     /// <envoy_api_field_config.core.v3.BackoffStrategy.max_interval>`.
     #[prost(message, optional, tag = "1")]
-    pub base_interval: ::core::option::Option<::prost_types::Duration>,
+    pub base_interval: ::std::option::Option<::prost_types::Duration>,
     /// Specifies the maximum interval between retries. This parameter is optional,
     /// but must be greater than or equal to the :ref:`base_interval
     /// <envoy_api_field_config.core.v3.BackoffStrategy.base_interval>` if set. The default
     /// is 10 times the :ref:`base_interval
     /// <envoy_api_field_config.core.v3.BackoffStrategy.base_interval>`.
     #[prost(message, optional, tag = "2")]
-    pub max_interval: ::core::option::Option<::prost_types::Duration>,
+    pub max_interval: ::std::option::Option<::prost_types::Duration>,
 }
 // [#protodoc-title: HTTP Service URI ]
 
@@ -208,18 +205,17 @@ pub struct HttpUri {
     ///    uri: https://www.googleapis.com/oauth2/v1/certs
     ///
     #[prost(string, tag = "1")]
-    pub uri: ::prost::alloc::string::String,
+    pub uri: std::string::String,
     /// Sets the maximum duration in milliseconds that a response can take to arrive upon request.
     #[prost(message, optional, tag = "3")]
-    pub timeout: ::core::option::Option<::prost_types::Duration>,
+    pub timeout: ::std::option::Option<::prost_types::Duration>,
     /// Specify how `uri` is to be fetched. Today, this requires an explicit
     /// cluster, but in the future we may support dynamic cluster creation or
     /// inline DNS resolution. See `issue
     /// <https://github.com/envoyproxy/envoy/issues/1606>`_.
     #[prost(oneof = "http_uri::HttpUpstreamType", tags = "2")]
-    pub http_upstream_type: ::core::option::Option<http_uri::HttpUpstreamType>,
+    pub http_upstream_type: ::std::option::Option<http_uri::HttpUpstreamType>,
 }
-/// Nested message and enum types in `HttpUri`.
 pub mod http_uri {
     /// Specify how `uri` is to be fetched. Today, this requires an explicit
     /// cluster, but in the future we may support dynamic cluster creation or
@@ -237,7 +233,7 @@ pub mod http_uri {
         ///    cluster: jwks_cluster
         ///
         #[prost(string, tag = "2")]
-        Cluster(::prost::alloc::string::String),
+        Cluster(std::string::String),
     }
 }
 /// Identifies location of where either Envoy runs or where upstream hosts run.
@@ -245,7 +241,7 @@ pub mod http_uri {
 pub struct Locality {
     /// Region this :ref:`zone <envoy_api_field_config.core.v3.Locality.zone>` belongs to.
     #[prost(string, tag = "1")]
-    pub region: ::prost::alloc::string::String,
+    pub region: std::string::String,
     /// Defines the local service zone where Envoy is running. Though optional, it
     /// should be set if discovery service routing is used and the discovery
     /// service exposes :ref:`zone data <envoy_api_field_config.endpoint.v3.LocalityLbEndpoints.locality>`,
@@ -255,12 +251,12 @@ pub struct Locality {
     /// on AWS, `Zone <https://cloud.google.com/compute/docs/regions-zones/>`_ on
     /// GCP, etc.
     #[prost(string, tag = "2")]
-    pub zone: ::prost::alloc::string::String,
+    pub zone: std::string::String,
     /// When used for locality of upstream hosts, this field further splits zone
     /// into smaller chunks of sub-zones so they can be load balanced
     /// independently.
     #[prost(string, tag = "3")]
-    pub sub_zone: ::prost::alloc::string::String,
+    pub sub_zone: std::string::String,
 }
 /// BuildVersion combines SemVer version of extension with free-form build information
 /// (i.e. 'alpha', 'private-build') as a set of strings.
@@ -268,11 +264,11 @@ pub struct Locality {
 pub struct BuildVersion {
     /// SemVer version of extension.
     #[prost(message, optional, tag = "1")]
-    pub version: ::core::option::Option<super::super::super::r#type::v3::SemanticVersion>,
+    pub version: ::std::option::Option<super::super::super::r#type::v3::SemanticVersion>,
     /// Free-form build information.
     /// Envoy defines several well known keys in the source/common/common/version.h file
     #[prost(message, optional, tag = "2")]
-    pub metadata: ::core::option::Option<::prost_types::Struct>,
+    pub metadata: ::std::option::Option<::prost_types::Struct>,
 }
 /// Version and identification for an Envoy extension.
 /// [#next-free-field: 6]
@@ -281,24 +277,24 @@ pub struct Extension {
     /// This is the name of the Envoy filter as specified in the Envoy
     /// configuration, e.g. envoy.filters.http.router, com.acme.widget.
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
+    pub name: std::string::String,
     /// Category of the extension.
     /// Extension category names use reverse DNS notation. For instance "envoy.filters.listener"
     /// for Envoy's built-in listener filters or "com.acme.filters.http" for HTTP filters from
     /// acme.com vendor.
     /// [#comment:TODO(yanavlasov): Link to the doc with existing envoy category names.]
     #[prost(string, tag = "2")]
-    pub category: ::prost::alloc::string::String,
+    pub category: std::string::String,
     /// [#not-implemented-hide:] Type descriptor of extension configuration proto.
     /// [#comment:TODO(yanavlasov): Link to the doc with existing configuration protos.]
     /// [#comment:TODO(yanavlasov): Add tests when PR #9391 lands.]
     #[prost(string, tag = "3")]
-    pub type_descriptor: ::prost::alloc::string::String,
+    pub type_descriptor: std::string::String,
     /// The version is a property of the extension and maintained independently
     /// of other extensions and the Envoy API.
     /// This field is not set when extension did not provide version information.
     #[prost(message, optional, tag = "4")]
-    pub version: ::core::option::Option<BuildVersion>,
+    pub version: ::std::option::Option<BuildVersion>,
     /// Indicates that the extension is present but was disabled via dynamic configuration.
     #[prost(bool, tag = "5")]
     pub disabled: bool,
@@ -316,7 +312,7 @@ pub struct Node {
     /// <arch_overview_tracing>`, either in this message or via
     /// :option:`--service-node`.
     #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
+    pub id: std::string::String,
     /// Defines the local service cluster name where Envoy is running. Though
     /// optional, it should be set if any of the following features are used:
     /// :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
@@ -330,45 +326,44 @@ pub struct Node {
     /// <arch_overview_tracing>`, either in this message or via
     /// :option:`--service-cluster`.
     #[prost(string, tag = "2")]
-    pub cluster: ::prost::alloc::string::String,
+    pub cluster: std::string::String,
     /// Opaque metadata extending the node identifier. Envoy will pass this
     /// directly to the management server.
     #[prost(message, optional, tag = "3")]
-    pub metadata: ::core::option::Option<::prost_types::Struct>,
+    pub metadata: ::std::option::Option<::prost_types::Struct>,
     /// Locality specifying where the Envoy instance is running.
     #[prost(message, optional, tag = "4")]
-    pub locality: ::core::option::Option<Locality>,
+    pub locality: ::std::option::Option<Locality>,
     /// Free-form string that identifies the entity requesting config.
     /// E.g. "envoy" or "grpc"
     #[prost(string, tag = "6")]
-    pub user_agent_name: ::prost::alloc::string::String,
+    pub user_agent_name: std::string::String,
     /// List of extensions and their versions supported by the node.
     #[prost(message, repeated, tag = "9")]
-    pub extensions: ::prost::alloc::vec::Vec<Extension>,
+    pub extensions: ::std::vec::Vec<Extension>,
     /// Client feature support list. These are well known features described
     /// in the Envoy API repository for a given major version of an API. Client features
     /// use reverse DNS naming scheme, for example `com.acme.feature`.
     /// See :ref:`the list of features <client_features>` that xDS client may
     /// support.
     #[prost(string, repeated, tag = "10")]
-    pub client_features: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub client_features: ::std::vec::Vec<std::string::String>,
     /// Known listening ports on the node as a generic hint to the management server
     /// for filtering :ref:`listeners <config_listeners>` to be returned. For example,
     /// if there is a listener bound to port 80, the list can optionally contain the
     /// SocketAddress `(0.0.0.0,80)`. The field is optional and just a hint.
     #[prost(message, repeated, tag = "11")]
-    pub listening_addresses: ::prost::alloc::vec::Vec<Address>,
+    pub listening_addresses: ::std::vec::Vec<Address>,
     #[prost(oneof = "node::UserAgentVersionType", tags = "7, 8")]
-    pub user_agent_version_type: ::core::option::Option<node::UserAgentVersionType>,
+    pub user_agent_version_type: ::std::option::Option<node::UserAgentVersionType>,
 }
-/// Nested message and enum types in `Node`.
 pub mod node {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum UserAgentVersionType {
         /// Free-form string that identifies the version of the entity requesting config.
         /// E.g. "1.12.2" or "abcd1234", or "SpecialEnvoyBuild"
         #[prost(string, tag = "7")]
-        UserAgentVersion(::prost::alloc::string::String),
+        UserAgentVersion(std::string::String),
         /// Structured version of the entity requesting config.
         #[prost(message, tag = "8")]
         UserAgentBuildVersion(super::BuildVersion),
@@ -401,8 +396,7 @@ pub struct Metadata {
     /// Key is the reverse DNS filter name, e.g. com.acme.widget. The envoy.*
     /// namespace is reserved for Envoy's built-in filters.
     #[prost(map = "string, message", tag = "1")]
-    pub filter_metadata:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Struct>,
+    pub filter_metadata: ::std::collections::HashMap<std::string::String, ::prost_types::Struct>,
 }
 /// Runtime derived uint32 with a default when not specified.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -412,7 +406,7 @@ pub struct RuntimeUInt32 {
     pub default_value: u32,
     /// Runtime key to get value for comparison. This value is used if defined.
     #[prost(string, tag = "3")]
-    pub runtime_key: ::prost::alloc::string::String,
+    pub runtime_key: std::string::String,
 }
 /// Runtime derived double with a default when not specified.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -422,70 +416,69 @@ pub struct RuntimeDouble {
     pub default_value: f64,
     /// Runtime key to get value for comparison. This value is used if defined.
     #[prost(string, tag = "2")]
-    pub runtime_key: ::prost::alloc::string::String,
+    pub runtime_key: std::string::String,
 }
 /// Runtime derived bool with a default when not specified.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RuntimeFeatureFlag {
     /// Default value if runtime value is not available.
     #[prost(message, optional, tag = "1")]
-    pub default_value: ::core::option::Option<bool>,
+    pub default_value: ::std::option::Option<bool>,
     /// Runtime key to get value for comparison. This value is used if defined. The boolean value must
     /// be represented via its
     /// `canonical JSON encoding <https://developers.google.com/protocol-buffers/docs/proto3#json>`_.
     #[prost(string, tag = "2")]
-    pub runtime_key: ::prost::alloc::string::String,
+    pub runtime_key: std::string::String,
 }
 /// Header name/value pair.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HeaderValue {
     /// Header name.
     #[prost(string, tag = "1")]
-    pub key: ::prost::alloc::string::String,
+    pub key: std::string::String,
     /// Header value.
     ///
     /// The same :ref:`format specifier <config_access_log_format>` as used for
     /// :ref:`HTTP access logging <config_access_log>` applies here, however
     /// unknown header values are replaced with the empty string instead of `-`.
     #[prost(string, tag = "2")]
-    pub value: ::prost::alloc::string::String,
+    pub value: std::string::String,
 }
 /// Header name/value pair plus option to control append behavior.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HeaderValueOption {
     /// Header name/value pair that this option applies to.
     #[prost(message, optional, tag = "1")]
-    pub header: ::core::option::Option<HeaderValue>,
+    pub header: ::std::option::Option<HeaderValue>,
     /// Should the value be appended? If true (default), the value is appended to
     /// existing values.
     #[prost(message, optional, tag = "2")]
-    pub append: ::core::option::Option<bool>,
+    pub append: ::std::option::Option<bool>,
 }
 /// Wrapper for a set of headers.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HeaderMap {
     #[prost(message, repeated, tag = "1")]
-    pub headers: ::prost::alloc::vec::Vec<HeaderValue>,
+    pub headers: ::std::vec::Vec<HeaderValue>,
 }
 /// Data source consisting of either a file or an inline value.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DataSource {
     #[prost(oneof = "data_source::Specifier", tags = "1, 2, 3")]
-    pub specifier: ::core::option::Option<data_source::Specifier>,
+    pub specifier: ::std::option::Option<data_source::Specifier>,
 }
-/// Nested message and enum types in `DataSource`.
 pub mod data_source {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Specifier {
         /// Local filesystem data source.
         #[prost(string, tag = "1")]
-        Filename(::prost::alloc::string::String),
+        Filename(std::string::String),
         /// Bytes inlined in the configuration.
         #[prost(bytes, tag = "2")]
-        InlineBytes(::prost::alloc::vec::Vec<u8>),
+        InlineBytes(std::vec::Vec<u8>),
         /// String inlined in the configuration.
         #[prost(string, tag = "3")]
-        InlineString(::prost::alloc::string::String),
+        InlineString(std::string::String),
     }
 }
 /// The message specifies the retry policy of remote data source when fetching fails.
@@ -495,32 +488,31 @@ pub struct RetryPolicy {
     /// This parameter is optional, in which case the default base interval is 1000 milliseconds. The
     /// default maximum interval is 10 times the base interval.
     #[prost(message, optional, tag = "1")]
-    pub retry_back_off: ::core::option::Option<BackoffStrategy>,
+    pub retry_back_off: ::std::option::Option<BackoffStrategy>,
     /// Specifies the allowed number of retries. This parameter is optional and
     /// defaults to 1.
     #[prost(message, optional, tag = "2")]
-    pub num_retries: ::core::option::Option<u32>,
+    pub num_retries: ::std::option::Option<u32>,
 }
 /// The message specifies how to fetch data from remote and how to verify it.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoteDataSource {
     /// The HTTP URI to fetch the remote data.
     #[prost(message, optional, tag = "1")]
-    pub http_uri: ::core::option::Option<HttpUri>,
+    pub http_uri: ::std::option::Option<HttpUri>,
     /// SHA256 string for verifying data.
     #[prost(string, tag = "2")]
-    pub sha256: ::prost::alloc::string::String,
+    pub sha256: std::string::String,
     /// Retry policy for fetching remote data.
     #[prost(message, optional, tag = "3")]
-    pub retry_policy: ::core::option::Option<RetryPolicy>,
+    pub retry_policy: ::std::option::Option<RetryPolicy>,
 }
 /// Async data source which support async data fetch.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AsyncDataSource {
     #[prost(oneof = "async_data_source::Specifier", tags = "1, 2")]
-    pub specifier: ::core::option::Option<async_data_source::Specifier>,
+    pub specifier: ::std::option::Option<async_data_source::Specifier>,
 }
-/// Nested message and enum types in `AsyncDataSource`.
 pub mod async_data_source {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Specifier {
@@ -541,13 +533,12 @@ pub struct TransportSocket {
     /// The name of the transport socket to instantiate. The name must match a supported transport
     /// socket implementation.
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
+    pub name: std::string::String,
     /// Implementation specific configuration which depends on the implementation being instantiated.
     /// See the supported transport socket implementations for further documentation.
     #[prost(oneof = "transport_socket::ConfigType", tags = "3")]
-    pub config_type: ::core::option::Option<transport_socket::ConfigType>,
+    pub config_type: ::std::option::Option<transport_socket::ConfigType>,
 }
-/// Nested message and enum types in `TransportSocket`.
 pub mod transport_socket {
     /// Implementation specific configuration which depends on the implementation being instantiated.
     /// See the supported transport socket implementations for further documentation.
@@ -571,10 +562,10 @@ pub mod transport_socket {
 pub struct RuntimeFractionalPercent {
     /// Default value if the runtime value's for the numerator/denominator keys are not available.
     #[prost(message, optional, tag = "1")]
-    pub default_value: ::core::option::Option<super::super::super::r#type::v3::FractionalPercent>,
+    pub default_value: ::std::option::Option<super::super::super::r#type::v3::FractionalPercent>,
     /// Runtime key for a YAML representation of a FractionalPercent.
     #[prost(string, tag = "2")]
-    pub runtime_key: ::prost::alloc::string::String,
+    pub runtime_key: std::string::String,
 }
 /// Identifies a specific ControlPlane instance that Envoy is connected to.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -583,7 +574,7 @@ pub struct ControlPlane {
     /// of control plane. This can be used to identify which control plane instance,
     /// the Envoy is connected to.
     #[prost(string, tag = "1")]
-    pub identifier: ::prost::alloc::string::String,
+    pub identifier: std::string::String,
 }
 // [#protodoc-title: Common types]
 

--- a/limitador-server/src/envoy_rls/protobufs/envoy.extensions.common.ratelimit.v3.rs
+++ b/limitador-server/src/envoy_rls/protobufs/envoy.extensions.common.ratelimit.v3.rs
@@ -45,17 +45,16 @@
 pub struct RateLimitDescriptor {
     /// Descriptor entries.
     #[prost(message, repeated, tag = "1")]
-    pub entries: ::prost::alloc::vec::Vec<rate_limit_descriptor::Entry>,
+    pub entries: ::std::vec::Vec<rate_limit_descriptor::Entry>,
 }
-/// Nested message and enum types in `RateLimitDescriptor`.
 pub mod rate_limit_descriptor {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Entry {
         /// Descriptor key.
         #[prost(string, tag = "1")]
-        pub key: ::prost::alloc::string::String,
+        pub key: std::string::String,
         /// Descriptor value.
         #[prost(string, tag = "2")]
-        pub value: ::prost::alloc::string::String,
+        pub value: std::string::String,
     }
 }

--- a/limitador-server/src/envoy_rls/protobufs/envoy.r#type.v3.rs
+++ b/limitador-server/src/envoy_rls/protobufs/envoy.r#type.v3.rs
@@ -22,7 +22,6 @@ pub struct FractionalPercent {
     #[prost(enumeration = "fractional_percent::DenominatorType", tag = "2")]
     pub denominator: i32,
 }
-/// Nested message and enum types in `FractionalPercent`.
 pub mod fractional_percent {
     /// Fraction percentages support several fixed denominator values.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/limitador-server/src/envoy_rls/protobufs/envoy.service.ratelimit.v3.rs
+++ b/limitador-server/src/envoy_rls/protobufs/envoy.service.ratelimit.v3.rs
@@ -10,12 +10,12 @@ pub struct RateLimitRequest {
     /// All rate limit requests must specify a domain. This enables the configuration to be per
     /// application without fear of overlap. E.g., "envoy".
     #[prost(string, tag = "1")]
-    pub domain: ::prost::alloc::string::String,
+    pub domain: std::string::String,
     /// All rate limit requests must specify at least one RateLimitDescriptor. Each descriptor is
     /// processed by the service (see below). If any of the descriptors are over limit, the entire
     /// request is considered to be over limit.
     #[prost(message, repeated, tag = "2")]
-    pub descriptors: ::prost::alloc::vec::Vec<
+    pub descriptors: ::std::vec::Vec<
         super::super::super::extensions::common::ratelimit::v3::RateLimitDescriptor,
     >,
     /// Rate limit requests can optionally specify the number of hits a request adds to the matched
@@ -34,24 +34,22 @@ pub struct RateLimitResponse {
     /// in the RateLimitRequest. This can be used by the caller to determine which individual
     /// descriptors failed and/or what the currently configured limits are for all of them.
     #[prost(message, repeated, tag = "2")]
-    pub statuses: ::prost::alloc::vec::Vec<rate_limit_response::DescriptorStatus>,
+    pub statuses: ::std::vec::Vec<rate_limit_response::DescriptorStatus>,
     /// A list of headers to add to the response
     #[prost(message, repeated, tag = "3")]
     pub response_headers_to_add:
-        ::prost::alloc::vec::Vec<super::super::super::config::core::v3::HeaderValue>,
+        ::std::vec::Vec<super::super::super::config::core::v3::HeaderValue>,
     /// A list of headers to add to the request when forwarded
     #[prost(message, repeated, tag = "4")]
-    pub request_headers_to_add:
-        ::prost::alloc::vec::Vec<super::super::super::config::core::v3::HeaderValue>,
+    pub request_headers_to_add: ::std::vec::Vec<super::super::super::config::core::v3::HeaderValue>,
 }
-/// Nested message and enum types in `RateLimitResponse`.
 pub mod rate_limit_response {
     /// Defines an actual rate limit in terms of requests per unit of time and the unit itself.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RateLimit {
         /// A name or description of this limit.
         #[prost(string, tag = "3")]
-        pub name: ::prost::alloc::string::String,
+        pub name: std::string::String,
         /// The number of requests per unit of time.
         #[prost(uint32, tag = "1")]
         pub requests_per_unit: u32,
@@ -59,7 +57,6 @@ pub mod rate_limit_response {
         #[prost(enumeration = "rate_limit::Unit", tag = "2")]
         pub unit: i32,
     }
-    /// Nested message and enum types in `RateLimit`.
     pub mod rate_limit {
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
         #[repr(i32)]
@@ -83,7 +80,7 @@ pub mod rate_limit_response {
         pub code: i32,
         /// The current limit as configured by the server. Useful for debugging, etc.
         #[prost(message, optional, tag = "2")]
-        pub current_limit: ::core::option::Option<RateLimit>,
+        pub current_limit: ::std::option::Option<RateLimit>,
         /// The limit remaining in the current time unit.
         #[prost(uint32, tag = "3")]
         pub limit_remaining: u32,
@@ -177,6 +174,7 @@ pub mod rate_limit_service_server {
         ) -> Result<tonic::Response<super::RateLimitResponse>, tonic::Status>;
     }
     #[derive(Debug)]
+    #[doc(hidden)]
     pub struct RateLimitServiceServer<T: RateLimitService> {
         inner: _Inner<T>,
     }
@@ -221,7 +219,7 @@ pub mod rate_limit_service_server {
                             request: tonic::Request<super::RateLimitRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).should_rate_limit(request).await };
+                            let fut = async move { inner.should_rate_limit(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -245,7 +243,6 @@ pub mod rate_limit_service_server {
                     Ok(http::Response::builder()
                         .status(200)
                         .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
                         .body(tonic::body::BoxBody::empty())
                         .unwrap())
                 }),

--- a/limitador-server/src/envoy_rls/protobufs/udpa.annotations.rs
+++ b/limitador-server/src/envoy_rls/protobufs/udpa.annotations.rs
@@ -26,5 +26,5 @@ pub struct VersioningAnnotation {
     /// udpa.foo.v3alpha.Foo and it was previously udpa.bar.v2.Bar. This
     /// information is consumed by UDPA via proto descriptors.
     #[prost(string, tag = "1")]
-    pub previous_message_type: ::prost::alloc::string::String,
+    pub previous_message_type: std::string::String,
 }

--- a/limitador-server/src/envoy_rls/protobufs/validate.rs
+++ b/limitador-server/src/envoy_rls/protobufs/validate.rs
@@ -3,14 +3,13 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldRules {
     #[prost(message, optional, tag = "17")]
-    pub message: ::core::option::Option<MessageRules>,
+    pub message: ::std::option::Option<MessageRules>,
     #[prost(
         oneof = "field_rules::Type",
         tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 22"
     )]
-    pub r#type: ::core::option::Option<field_rules::Type>,
+    pub r#type: ::std::option::Option<field_rules::Type>,
 }
-/// Nested message and enum types in `FieldRules`.
 pub mod field_rules {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Type {
@@ -49,9 +48,9 @@ pub mod field_rules {
         #[prost(message, tag = "16")]
         Enum(super::EnumRules),
         #[prost(message, tag = "18")]
-        Repeated(::prost::alloc::boxed::Box<super::RepeatedRules>),
+        Repeated(Box<super::RepeatedRules>),
         #[prost(message, tag = "19")]
-        Map(::prost::alloc::boxed::Box<super::MapRules>),
+        Map(Box<super::MapRules>),
         /// Well-Known Field Types
         #[prost(message, tag = "20")]
         Any(super::AnyRules),
@@ -66,482 +65,481 @@ pub mod field_rules {
 pub struct FloatRules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(float, optional, tag = "1")]
-    pub r#const: ::core::option::Option<f32>,
+    pub r#const: ::std::option::Option<f32>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(float, optional, tag = "2")]
-    pub lt: ::core::option::Option<f32>,
+    pub lt: ::std::option::Option<f32>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(float, optional, tag = "3")]
-    pub lte: ::core::option::Option<f32>,
+    pub lte: ::std::option::Option<f32>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(float, optional, tag = "4")]
-    pub gt: ::core::option::Option<f32>,
+    pub gt: ::std::option::Option<f32>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(float, optional, tag = "5")]
-    pub gte: ::core::option::Option<f32>,
+    pub gte: ::std::option::Option<f32>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(float, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<f32>,
+    pub r#in: ::std::vec::Vec<f32>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(float, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<f32>,
+    pub not_in: ::std::vec::Vec<f32>,
 }
 /// DoubleRules describes the constraints applied to `double` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DoubleRules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(double, optional, tag = "1")]
-    pub r#const: ::core::option::Option<f64>,
+    pub r#const: ::std::option::Option<f64>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(double, optional, tag = "2")]
-    pub lt: ::core::option::Option<f64>,
+    pub lt: ::std::option::Option<f64>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(double, optional, tag = "3")]
-    pub lte: ::core::option::Option<f64>,
+    pub lte: ::std::option::Option<f64>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(double, optional, tag = "4")]
-    pub gt: ::core::option::Option<f64>,
+    pub gt: ::std::option::Option<f64>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(double, optional, tag = "5")]
-    pub gte: ::core::option::Option<f64>,
+    pub gte: ::std::option::Option<f64>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(double, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<f64>,
+    pub r#in: ::std::vec::Vec<f64>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(double, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<f64>,
+    pub not_in: ::std::vec::Vec<f64>,
 }
 /// Int32Rules describes the constraints applied to `int32` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Int32Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(int32, optional, tag = "1")]
-    pub r#const: ::core::option::Option<i32>,
+    pub r#const: ::std::option::Option<i32>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(int32, optional, tag = "2")]
-    pub lt: ::core::option::Option<i32>,
+    pub lt: ::std::option::Option<i32>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(int32, optional, tag = "3")]
-    pub lte: ::core::option::Option<i32>,
+    pub lte: ::std::option::Option<i32>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(int32, optional, tag = "4")]
-    pub gt: ::core::option::Option<i32>,
+    pub gt: ::std::option::Option<i32>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(int32, optional, tag = "5")]
-    pub gte: ::core::option::Option<i32>,
+    pub gte: ::std::option::Option<i32>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(int32, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<i32>,
+    pub r#in: ::std::vec::Vec<i32>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(int32, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<i32>,
+    pub not_in: ::std::vec::Vec<i32>,
 }
 /// Int64Rules describes the constraints applied to `int64` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Int64Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(int64, optional, tag = "1")]
-    pub r#const: ::core::option::Option<i64>,
+    pub r#const: ::std::option::Option<i64>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(int64, optional, tag = "2")]
-    pub lt: ::core::option::Option<i64>,
+    pub lt: ::std::option::Option<i64>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(int64, optional, tag = "3")]
-    pub lte: ::core::option::Option<i64>,
+    pub lte: ::std::option::Option<i64>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(int64, optional, tag = "4")]
-    pub gt: ::core::option::Option<i64>,
+    pub gt: ::std::option::Option<i64>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(int64, optional, tag = "5")]
-    pub gte: ::core::option::Option<i64>,
+    pub gte: ::std::option::Option<i64>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(int64, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<i64>,
+    pub r#in: ::std::vec::Vec<i64>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(int64, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<i64>,
+    pub not_in: ::std::vec::Vec<i64>,
 }
 /// UInt32Rules describes the constraints applied to `uint32` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UInt32Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(uint32, optional, tag = "1")]
-    pub r#const: ::core::option::Option<u32>,
+    pub r#const: ::std::option::Option<u32>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(uint32, optional, tag = "2")]
-    pub lt: ::core::option::Option<u32>,
+    pub lt: ::std::option::Option<u32>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(uint32, optional, tag = "3")]
-    pub lte: ::core::option::Option<u32>,
+    pub lte: ::std::option::Option<u32>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(uint32, optional, tag = "4")]
-    pub gt: ::core::option::Option<u32>,
+    pub gt: ::std::option::Option<u32>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(uint32, optional, tag = "5")]
-    pub gte: ::core::option::Option<u32>,
+    pub gte: ::std::option::Option<u32>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(uint32, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<u32>,
+    pub r#in: ::std::vec::Vec<u32>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(uint32, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<u32>,
+    pub not_in: ::std::vec::Vec<u32>,
 }
 /// UInt64Rules describes the constraints applied to `uint64` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UInt64Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(uint64, optional, tag = "1")]
-    pub r#const: ::core::option::Option<u64>,
+    pub r#const: ::std::option::Option<u64>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(uint64, optional, tag = "2")]
-    pub lt: ::core::option::Option<u64>,
+    pub lt: ::std::option::Option<u64>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(uint64, optional, tag = "3")]
-    pub lte: ::core::option::Option<u64>,
+    pub lte: ::std::option::Option<u64>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(uint64, optional, tag = "4")]
-    pub gt: ::core::option::Option<u64>,
+    pub gt: ::std::option::Option<u64>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(uint64, optional, tag = "5")]
-    pub gte: ::core::option::Option<u64>,
+    pub gte: ::std::option::Option<u64>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(uint64, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<u64>,
+    pub r#in: ::std::vec::Vec<u64>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(uint64, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<u64>,
+    pub not_in: ::std::vec::Vec<u64>,
 }
 /// SInt32Rules describes the constraints applied to `sint32` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SInt32Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(sint32, optional, tag = "1")]
-    pub r#const: ::core::option::Option<i32>,
+    pub r#const: ::std::option::Option<i32>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(sint32, optional, tag = "2")]
-    pub lt: ::core::option::Option<i32>,
+    pub lt: ::std::option::Option<i32>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(sint32, optional, tag = "3")]
-    pub lte: ::core::option::Option<i32>,
+    pub lte: ::std::option::Option<i32>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(sint32, optional, tag = "4")]
-    pub gt: ::core::option::Option<i32>,
+    pub gt: ::std::option::Option<i32>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(sint32, optional, tag = "5")]
-    pub gte: ::core::option::Option<i32>,
+    pub gte: ::std::option::Option<i32>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(sint32, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<i32>,
+    pub r#in: ::std::vec::Vec<i32>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(sint32, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<i32>,
+    pub not_in: ::std::vec::Vec<i32>,
 }
 /// SInt64Rules describes the constraints applied to `sint64` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SInt64Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(sint64, optional, tag = "1")]
-    pub r#const: ::core::option::Option<i64>,
+    pub r#const: ::std::option::Option<i64>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(sint64, optional, tag = "2")]
-    pub lt: ::core::option::Option<i64>,
+    pub lt: ::std::option::Option<i64>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(sint64, optional, tag = "3")]
-    pub lte: ::core::option::Option<i64>,
+    pub lte: ::std::option::Option<i64>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(sint64, optional, tag = "4")]
-    pub gt: ::core::option::Option<i64>,
+    pub gt: ::std::option::Option<i64>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(sint64, optional, tag = "5")]
-    pub gte: ::core::option::Option<i64>,
+    pub gte: ::std::option::Option<i64>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(sint64, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<i64>,
+    pub r#in: ::std::vec::Vec<i64>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(sint64, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<i64>,
+    pub not_in: ::std::vec::Vec<i64>,
 }
 /// Fixed32Rules describes the constraints applied to `fixed32` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Fixed32Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(fixed32, optional, tag = "1")]
-    pub r#const: ::core::option::Option<u32>,
+    pub r#const: ::std::option::Option<u32>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(fixed32, optional, tag = "2")]
-    pub lt: ::core::option::Option<u32>,
+    pub lt: ::std::option::Option<u32>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(fixed32, optional, tag = "3")]
-    pub lte: ::core::option::Option<u32>,
+    pub lte: ::std::option::Option<u32>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(fixed32, optional, tag = "4")]
-    pub gt: ::core::option::Option<u32>,
+    pub gt: ::std::option::Option<u32>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(fixed32, optional, tag = "5")]
-    pub gte: ::core::option::Option<u32>,
+    pub gte: ::std::option::Option<u32>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(fixed32, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<u32>,
+    pub r#in: ::std::vec::Vec<u32>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(fixed32, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<u32>,
+    pub not_in: ::std::vec::Vec<u32>,
 }
 /// Fixed64Rules describes the constraints applied to `fixed64` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Fixed64Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(fixed64, optional, tag = "1")]
-    pub r#const: ::core::option::Option<u64>,
+    pub r#const: ::std::option::Option<u64>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(fixed64, optional, tag = "2")]
-    pub lt: ::core::option::Option<u64>,
+    pub lt: ::std::option::Option<u64>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(fixed64, optional, tag = "3")]
-    pub lte: ::core::option::Option<u64>,
+    pub lte: ::std::option::Option<u64>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(fixed64, optional, tag = "4")]
-    pub gt: ::core::option::Option<u64>,
+    pub gt: ::std::option::Option<u64>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(fixed64, optional, tag = "5")]
-    pub gte: ::core::option::Option<u64>,
+    pub gte: ::std::option::Option<u64>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(fixed64, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<u64>,
+    pub r#in: ::std::vec::Vec<u64>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(fixed64, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<u64>,
+    pub not_in: ::std::vec::Vec<u64>,
 }
 /// SFixed32Rules describes the constraints applied to `sfixed32` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SFixed32Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(sfixed32, optional, tag = "1")]
-    pub r#const: ::core::option::Option<i32>,
+    pub r#const: ::std::option::Option<i32>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(sfixed32, optional, tag = "2")]
-    pub lt: ::core::option::Option<i32>,
+    pub lt: ::std::option::Option<i32>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(sfixed32, optional, tag = "3")]
-    pub lte: ::core::option::Option<i32>,
+    pub lte: ::std::option::Option<i32>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(sfixed32, optional, tag = "4")]
-    pub gt: ::core::option::Option<i32>,
+    pub gt: ::std::option::Option<i32>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(sfixed32, optional, tag = "5")]
-    pub gte: ::core::option::Option<i32>,
+    pub gte: ::std::option::Option<i32>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(sfixed32, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<i32>,
+    pub r#in: ::std::vec::Vec<i32>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(sfixed32, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<i32>,
+    pub not_in: ::std::vec::Vec<i32>,
 }
 /// SFixed64Rules describes the constraints applied to `sfixed64` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SFixed64Rules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(sfixed64, optional, tag = "1")]
-    pub r#const: ::core::option::Option<i64>,
+    pub r#const: ::std::option::Option<i64>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(sfixed64, optional, tag = "2")]
-    pub lt: ::core::option::Option<i64>,
+    pub lt: ::std::option::Option<i64>,
     /// Lte specifies that this field must be less than or equal to the
     /// specified value, inclusive
     #[prost(sfixed64, optional, tag = "3")]
-    pub lte: ::core::option::Option<i64>,
+    pub lte: ::std::option::Option<i64>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     /// range is reversed.
     #[prost(sfixed64, optional, tag = "4")]
-    pub gt: ::core::option::Option<i64>,
+    pub gt: ::std::option::Option<i64>,
     /// Gte specifies that this field must be greater than or equal to the
     /// specified value, inclusive. If the value of Gte is larger than a
     /// specified Lt or Lte, the range is reversed.
     #[prost(sfixed64, optional, tag = "5")]
-    pub gte: ::core::option::Option<i64>,
+    pub gte: ::std::option::Option<i64>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(sfixed64, repeated, packed = "false", tag = "6")]
-    pub r#in: ::prost::alloc::vec::Vec<i64>,
+    pub r#in: ::std::vec::Vec<i64>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(sfixed64, repeated, packed = "false", tag = "7")]
-    pub not_in: ::prost::alloc::vec::Vec<i64>,
+    pub not_in: ::std::vec::Vec<i64>,
 }
 /// BoolRules describes the constraints applied to `bool` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BoolRules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(bool, optional, tag = "1")]
-    pub r#const: ::core::option::Option<bool>,
+    pub r#const: ::std::option::Option<bool>,
 }
 /// StringRules describe the constraints applied to `string` values
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StringRules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(string, optional, tag = "1")]
-    pub r#const: ::core::option::Option<::prost::alloc::string::String>,
+    pub r#const: ::std::option::Option<std::string::String>,
     /// Len specifies that this field must be the specified number of
     /// characters (Unicode code points). Note that the number of
     /// characters may differ from the number of bytes in the string.
     #[prost(uint64, optional, tag = "19")]
-    pub len: ::core::option::Option<u64>,
+    pub len: ::std::option::Option<u64>,
     /// MinLen specifies that this field must be the specified number of
     /// characters (Unicode code points) at a minimum. Note that the number of
     /// characters may differ from the number of bytes in the string.
     #[prost(uint64, optional, tag = "2")]
-    pub min_len: ::core::option::Option<u64>,
+    pub min_len: ::std::option::Option<u64>,
     /// MaxLen specifies that this field must be the specified number of
     /// characters (Unicode code points) at a maximum. Note that the number of
     /// characters may differ from the number of bytes in the string.
     #[prost(uint64, optional, tag = "3")]
-    pub max_len: ::core::option::Option<u64>,
+    pub max_len: ::std::option::Option<u64>,
     /// LenBytes specifies that this field must be the specified number of bytes
     /// at a minimum
     #[prost(uint64, optional, tag = "20")]
-    pub len_bytes: ::core::option::Option<u64>,
+    pub len_bytes: ::std::option::Option<u64>,
     /// MinBytes specifies that this field must be the specified number of bytes
     /// at a minimum
     #[prost(uint64, optional, tag = "4")]
-    pub min_bytes: ::core::option::Option<u64>,
+    pub min_bytes: ::std::option::Option<u64>,
     /// MaxBytes specifies that this field must be the specified number of bytes
     /// at a maximum
     #[prost(uint64, optional, tag = "5")]
-    pub max_bytes: ::core::option::Option<u64>,
+    pub max_bytes: ::std::option::Option<u64>,
     /// Pattern specifes that this field must match against the specified
     /// regular expression (RE2 syntax). The included expression should elide
     /// any delimiters.
     #[prost(string, optional, tag = "6")]
-    pub pattern: ::core::option::Option<::prost::alloc::string::String>,
+    pub pattern: ::std::option::Option<std::string::String>,
     /// Prefix specifies that this field must have the specified substring at
     /// the beginning of the string.
     #[prost(string, optional, tag = "7")]
-    pub prefix: ::core::option::Option<::prost::alloc::string::String>,
+    pub prefix: ::std::option::Option<std::string::String>,
     /// Suffix specifies that this field must have the specified substring at
     /// the end of the string.
     #[prost(string, optional, tag = "8")]
-    pub suffix: ::core::option::Option<::prost::alloc::string::String>,
+    pub suffix: ::std::option::Option<std::string::String>,
     /// Contains specifies that this field must have the specified substring
     /// anywhere in the string.
     #[prost(string, optional, tag = "9")]
-    pub contains: ::core::option::Option<::prost::alloc::string::String>,
+    pub contains: ::std::option::Option<std::string::String>,
     /// NotContains specifies that this field cannot have the specified substring
     /// anywhere in the string.
     #[prost(string, optional, tag = "23")]
-    pub not_contains: ::core::option::Option<::prost::alloc::string::String>,
+    pub not_contains: ::std::option::Option<std::string::String>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(string, repeated, tag = "10")]
-    pub r#in: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub r#in: ::std::vec::Vec<std::string::String>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(string, repeated, tag = "11")]
-    pub not_in: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub not_in: ::std::vec::Vec<std::string::String>,
     /// This applies to regexes HTTP_HEADER_NAME and HTTP_HEADER_VALUE to enable
     /// strict header validation.
     /// By default, this is true, and HTTP header validations are RFC-compliant.
     /// Setting to false will enable a looser validations that only disallows
     /// \r\n\0 characters, which can be used to bypass header matching rules.
     #[prost(bool, optional, tag = "25", default = "true")]
-    pub strict: ::core::option::Option<bool>,
+    pub strict: ::std::option::Option<bool>,
     /// WellKnown rules provide advanced constraints against common string
     /// patterns
     #[prost(
         oneof = "string_rules::WellKnown",
         tags = "12, 13, 14, 15, 16, 17, 18, 21, 22, 24"
     )]
-    pub well_known: ::core::option::Option<string_rules::WellKnown>,
+    pub well_known: ::std::option::Option<string_rules::WellKnown>,
 }
-/// Nested message and enum types in `StringRules`.
 pub mod string_rules {
     /// WellKnown rules provide advanced constraints against common string
     /// patterns
@@ -593,50 +591,49 @@ pub mod string_rules {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BytesRules {
     /// Const specifies that this field must be exactly the specified value
-    #[prost(bytes = "vec", optional, tag = "1")]
-    pub r#const: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes, optional, tag = "1")]
+    pub r#const: ::std::option::Option<std::vec::Vec<u8>>,
     /// Len specifies that this field must be the specified number of bytes
     #[prost(uint64, optional, tag = "13")]
-    pub len: ::core::option::Option<u64>,
+    pub len: ::std::option::Option<u64>,
     /// MinLen specifies that this field must be the specified number of bytes
     /// at a minimum
     #[prost(uint64, optional, tag = "2")]
-    pub min_len: ::core::option::Option<u64>,
+    pub min_len: ::std::option::Option<u64>,
     /// MaxLen specifies that this field must be the specified number of bytes
     /// at a maximum
     #[prost(uint64, optional, tag = "3")]
-    pub max_len: ::core::option::Option<u64>,
+    pub max_len: ::std::option::Option<u64>,
     /// Pattern specifes that this field must match against the specified
     /// regular expression (RE2 syntax). The included expression should elide
     /// any delimiters.
     #[prost(string, optional, tag = "4")]
-    pub pattern: ::core::option::Option<::prost::alloc::string::String>,
+    pub pattern: ::std::option::Option<std::string::String>,
     /// Prefix specifies that this field must have the specified bytes at the
     /// beginning of the string.
-    #[prost(bytes = "vec", optional, tag = "5")]
-    pub prefix: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes, optional, tag = "5")]
+    pub prefix: ::std::option::Option<std::vec::Vec<u8>>,
     /// Suffix specifies that this field must have the specified bytes at the
     /// end of the string.
-    #[prost(bytes = "vec", optional, tag = "6")]
-    pub suffix: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes, optional, tag = "6")]
+    pub suffix: ::std::option::Option<std::vec::Vec<u8>>,
     /// Contains specifies that this field must have the specified bytes
     /// anywhere in the string.
-    #[prost(bytes = "vec", optional, tag = "7")]
-    pub contains: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes, optional, tag = "7")]
+    pub contains: ::std::option::Option<std::vec::Vec<u8>>,
     /// In specifies that this field must be equal to one of the specified
     /// values
-    #[prost(bytes = "vec", repeated, tag = "8")]
-    pub r#in: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes, repeated, tag = "8")]
+    pub r#in: ::std::vec::Vec<std::vec::Vec<u8>>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
-    #[prost(bytes = "vec", repeated, tag = "9")]
-    pub not_in: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes, repeated, tag = "9")]
+    pub not_in: ::std::vec::Vec<std::vec::Vec<u8>>,
     /// WellKnown rules provide advanced constraints against common byte
     /// patterns
     #[prost(oneof = "bytes_rules::WellKnown", tags = "10, 11, 12")]
-    pub well_known: ::core::option::Option<bytes_rules::WellKnown>,
+    pub well_known: ::std::option::Option<bytes_rules::WellKnown>,
 }
-/// Nested message and enum types in `BytesRules`.
 pub mod bytes_rules {
     /// WellKnown rules provide advanced constraints against common byte
     /// patterns
@@ -661,19 +658,19 @@ pub mod bytes_rules {
 pub struct EnumRules {
     /// Const specifies that this field must be exactly the specified value
     #[prost(int32, optional, tag = "1")]
-    pub r#const: ::core::option::Option<i32>,
+    pub r#const: ::std::option::Option<i32>,
     /// DefinedOnly specifies that this field must be only one of the defined
     /// values for this enum, failing on any undefined value.
     #[prost(bool, optional, tag = "2")]
-    pub defined_only: ::core::option::Option<bool>,
+    pub defined_only: ::std::option::Option<bool>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(int32, repeated, packed = "false", tag = "3")]
-    pub r#in: ::prost::alloc::vec::Vec<i32>,
+    pub r#in: ::std::vec::Vec<i32>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(int32, repeated, packed = "false", tag = "4")]
-    pub not_in: ::prost::alloc::vec::Vec<i32>,
+    pub not_in: ::std::vec::Vec<i32>,
 }
 /// MessageRules describe the constraints applied to embedded message values.
 /// For message-type fields, validation is performed recursively.
@@ -682,10 +679,10 @@ pub struct MessageRules {
     /// Skip specifies that the validation rules of this field should not be
     /// evaluated
     #[prost(bool, optional, tag = "1")]
-    pub skip: ::core::option::Option<bool>,
+    pub skip: ::std::option::Option<bool>,
     /// Required specifies that this field must be set
     #[prost(bool, optional, tag = "2")]
-    pub required: ::core::option::Option<bool>,
+    pub required: ::std::option::Option<bool>,
 }
 /// RepeatedRules describe the constraints applied to `repeated` values
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -693,21 +690,21 @@ pub struct RepeatedRules {
     /// MinItems specifies that this field must have the specified number of
     /// items at a minimum
     #[prost(uint64, optional, tag = "1")]
-    pub min_items: ::core::option::Option<u64>,
+    pub min_items: ::std::option::Option<u64>,
     /// MaxItems specifies that this field must have the specified number of
     /// items at a maximum
     #[prost(uint64, optional, tag = "2")]
-    pub max_items: ::core::option::Option<u64>,
+    pub max_items: ::std::option::Option<u64>,
     /// Unique specifies that all elements in this field must be unique. This
     /// contraint is only applicable to scalar and enum types (messages are not
     /// supported).
     #[prost(bool, optional, tag = "3")]
-    pub unique: ::core::option::Option<bool>,
+    pub unique: ::std::option::Option<bool>,
     /// Items specifies the contraints to be applied to each item in the field.
     /// Repeated message fields will still execute validation against each item
     /// unless skip is specified here.
     #[prost(message, optional, boxed, tag = "4")]
-    pub items: ::core::option::Option<::prost::alloc::boxed::Box<FieldRules>>,
+    pub items: ::std::option::Option<::std::boxed::Box<FieldRules>>,
 }
 /// MapRules describe the constraints applied to `map` values
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -715,23 +712,23 @@ pub struct MapRules {
     /// MinPairs specifies that this field must have the specified number of
     /// KVs at a minimum
     #[prost(uint64, optional, tag = "1")]
-    pub min_pairs: ::core::option::Option<u64>,
+    pub min_pairs: ::std::option::Option<u64>,
     /// MaxPairs specifies that this field must have the specified number of
     /// KVs at a maximum
     #[prost(uint64, optional, tag = "2")]
-    pub max_pairs: ::core::option::Option<u64>,
+    pub max_pairs: ::std::option::Option<u64>,
     /// NoSparse specifies values in this field cannot be unset. This only
     /// applies to map's with message value types.
     #[prost(bool, optional, tag = "3")]
-    pub no_sparse: ::core::option::Option<bool>,
+    pub no_sparse: ::std::option::Option<bool>,
     /// Keys specifies the constraints to be applied to each key in the field.
     #[prost(message, optional, boxed, tag = "4")]
-    pub keys: ::core::option::Option<::prost::alloc::boxed::Box<FieldRules>>,
+    pub keys: ::std::option::Option<::std::boxed::Box<FieldRules>>,
     /// Values specifies the constraints to be applied to the value of each key
     /// in the field. Message values will still have their validations evaluated
     /// unless skip is specified here.
     #[prost(message, optional, boxed, tag = "5")]
-    pub values: ::core::option::Option<::prost::alloc::boxed::Box<FieldRules>>,
+    pub values: ::std::option::Option<::std::boxed::Box<FieldRules>>,
 }
 /// AnyRules describe constraints applied exclusively to the
 /// `google.protobuf.Any` well-known type
@@ -739,15 +736,15 @@ pub struct MapRules {
 pub struct AnyRules {
     /// Required specifies that this field must be set
     #[prost(bool, optional, tag = "1")]
-    pub required: ::core::option::Option<bool>,
+    pub required: ::std::option::Option<bool>,
     /// In specifies that this field's `type_url` must be equal to one of the
     /// specified values.
     #[prost(string, repeated, tag = "2")]
-    pub r#in: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub r#in: ::std::vec::Vec<std::string::String>,
     /// NotIn specifies that this field's `type_url` must not be equal to any of
     /// the specified values.
     #[prost(string, repeated, tag = "3")]
-    pub not_in: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub not_in: ::std::vec::Vec<std::string::String>,
 }
 /// DurationRules describe the constraints applied exclusively to the
 /// `google.protobuf.Duration` well-known type
@@ -755,34 +752,34 @@ pub struct AnyRules {
 pub struct DurationRules {
     /// Required specifies that this field must be set
     #[prost(bool, optional, tag = "1")]
-    pub required: ::core::option::Option<bool>,
+    pub required: ::std::option::Option<bool>,
     /// Const specifies that this field must be exactly the specified value
     #[prost(message, optional, tag = "2")]
-    pub r#const: ::core::option::Option<::prost_types::Duration>,
+    pub r#const: ::std::option::Option<::prost_types::Duration>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(message, optional, tag = "3")]
-    pub lt: ::core::option::Option<::prost_types::Duration>,
+    pub lt: ::std::option::Option<::prost_types::Duration>,
     /// Lt specifies that this field must be less than the specified value,
     /// inclusive
     #[prost(message, optional, tag = "4")]
-    pub lte: ::core::option::Option<::prost_types::Duration>,
+    pub lte: ::std::option::Option<::prost_types::Duration>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive
     #[prost(message, optional, tag = "5")]
-    pub gt: ::core::option::Option<::prost_types::Duration>,
+    pub gt: ::std::option::Option<::prost_types::Duration>,
     /// Gte specifies that this field must be greater than the specified value,
     /// inclusive
     #[prost(message, optional, tag = "6")]
-    pub gte: ::core::option::Option<::prost_types::Duration>,
+    pub gte: ::std::option::Option<::prost_types::Duration>,
     /// In specifies that this field must be equal to one of the specified
     /// values
     #[prost(message, repeated, tag = "7")]
-    pub r#in: ::prost::alloc::vec::Vec<::prost_types::Duration>,
+    pub r#in: ::std::vec::Vec<::prost_types::Duration>,
     /// NotIn specifies that this field cannot be equal to one of the specified
     /// values
     #[prost(message, repeated, tag = "8")]
-    pub not_in: ::prost::alloc::vec::Vec<::prost_types::Duration>,
+    pub not_in: ::std::vec::Vec<::prost_types::Duration>,
 }
 /// TimestampRules describe the constraints applied exclusively to the
 /// `google.protobuf.Timestamp` well-known type
@@ -790,39 +787,39 @@ pub struct DurationRules {
 pub struct TimestampRules {
     /// Required specifies that this field must be set
     #[prost(bool, optional, tag = "1")]
-    pub required: ::core::option::Option<bool>,
+    pub required: ::std::option::Option<bool>,
     /// Const specifies that this field must be exactly the specified value
     #[prost(message, optional, tag = "2")]
-    pub r#const: ::core::option::Option<::prost_types::Timestamp>,
+    pub r#const: ::std::option::Option<::prost_types::Timestamp>,
     /// Lt specifies that this field must be less than the specified value,
     /// exclusive
     #[prost(message, optional, tag = "3")]
-    pub lt: ::core::option::Option<::prost_types::Timestamp>,
+    pub lt: ::std::option::Option<::prost_types::Timestamp>,
     /// Lte specifies that this field must be less than the specified value,
     /// inclusive
     #[prost(message, optional, tag = "4")]
-    pub lte: ::core::option::Option<::prost_types::Timestamp>,
+    pub lte: ::std::option::Option<::prost_types::Timestamp>,
     /// Gt specifies that this field must be greater than the specified value,
     /// exclusive
     #[prost(message, optional, tag = "5")]
-    pub gt: ::core::option::Option<::prost_types::Timestamp>,
+    pub gt: ::std::option::Option<::prost_types::Timestamp>,
     /// Gte specifies that this field must be greater than the specified value,
     /// inclusive
     #[prost(message, optional, tag = "6")]
-    pub gte: ::core::option::Option<::prost_types::Timestamp>,
+    pub gte: ::std::option::Option<::prost_types::Timestamp>,
     /// LtNow specifies that this must be less than the current time. LtNow
     /// can only be used with the Within rule.
     #[prost(bool, optional, tag = "7")]
-    pub lt_now: ::core::option::Option<bool>,
+    pub lt_now: ::std::option::Option<bool>,
     /// GtNow specifies that this must be greater than the current time. GtNow
     /// can only be used with the Within rule.
     #[prost(bool, optional, tag = "8")]
-    pub gt_now: ::core::option::Option<bool>,
+    pub gt_now: ::std::option::Option<bool>,
     /// Within specifies that this field must be within this duration of the
     /// current time. This constraint can be used alone or with the LtNow and
     /// GtNow rules.
     #[prost(message, optional, tag = "9")]
-    pub within: ::core::option::Option<::prost_types::Duration>,
+    pub within: ::std::option::Option<::prost_types::Duration>,
 }
 /// WellKnownRegex contain some well-known patterns.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -15,26 +15,26 @@ default = ["redis_storage"]
 redis_storage = ["redis", "r2d2", "tokio"]
 
 [dependencies]
-ttl_cache = "^0.5"
-serde = { version = "^1", features = ["derive"] }
-serde_json = "^1"
-thiserror = "^1"
-futures = "^0.3"
-async-trait = "^0.1"
-cfg-if = "^1"
-prometheus = "^0.11"
-lazy_static = "^1.4"
+ttl_cache = "0.5"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+futures = "0.3"
+async-trait = "0.1.41"
+cfg-if = "1.0"
+prometheus = "0.10"
+lazy_static = "1.4"
 
 # Optional dependencies
-redis = { version = "^0.19", optional = true, features = ["connection-manager", "tokio-comp"] }
-r2d2 = { version = "^0.8", optional = true }
-tokio = { version = "^1", optional = true, features = ["rt", "macros", "time"] }
+redis = { version = "0.17", optional = true, features = ["connection-manager"] }
+r2d2 = { version = "0.8", optional = true }
+tokio = { version = "0.2", optional = true, features = ["rt-core", "macros", "time"] }
 
 [dev-dependencies]
-serial_test = "^0.5"
-criterion = "^0.3"
-paste = "^1"
-rand = "^0.8"
+serial_test = "0.5"
+criterion = "0.3"
+paste = "1.0"
+rand = "0.7"
 
 [[bench]]
 name = "bench"

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -1,7 +1,7 @@
 extern crate redis;
 
 use self::redis::aio::ConnectionManager;
-use self::redis::Client;
+use self::redis::ConnectionInfo;
 use crate::counter::Counter;
 use crate::limit::{Limit, Namespace};
 use crate::storage::redis::redis_keys::*;
@@ -10,6 +10,7 @@ use crate::storage::{AsyncStorage, StorageErr};
 use async_trait::async_trait;
 use redis::AsyncCommands;
 use std::collections::HashSet;
+use std::str::FromStr;
 use std::time::Duration;
 
 // Note: this implementation does no guarantee exact limits. Ensuring that we
@@ -216,7 +217,7 @@ impl AsyncStorage for AsyncRedisStorage {
 impl AsyncRedisStorage {
     pub async fn new(redis_url: &str) -> AsyncRedisStorage {
         AsyncRedisStorage {
-            conn_manager: ConnectionManager::new(Client::open(redis_url).unwrap())
+            conn_manager: ConnectionManager::new(ConnectionInfo::from_str(redis_url).unwrap())
                 .await
                 .unwrap(),
         }

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -11,8 +11,9 @@ use crate::storage::redis::scripts::VALUES_AND_TTLS;
 use crate::storage::{AsyncStorage, StorageErr};
 use async_trait::async_trait;
 use redis::aio::ConnectionManager;
-use redis::Client;
+use redis::ConnectionInfo;
 use std::collections::HashSet;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
@@ -220,9 +221,10 @@ impl CachedRedisStorage {
         ttl_cached_counters: Duration,
         ttl_ratio_cached_counters: u64,
     ) -> CachedRedisStorage {
-        let redis_conn_manager = ConnectionManager::new(Client::open(redis_url).unwrap())
-            .await
-            .unwrap();
+        let redis_conn_manager =
+            ConnectionManager::new(ConnectionInfo::from_str(redis_url).unwrap())
+                .await
+                .unwrap();
 
         let async_redis_storage =
             AsyncRedisStorage::new_with_conn_manager(redis_conn_manager.clone());
@@ -237,7 +239,7 @@ impl CachedRedisStorage {
                     let sleep_time = flushing_period
                         .checked_sub(time_start.elapsed())
                         .unwrap_or_else(|| Duration::from_secs(0));
-                    tokio::time::sleep(sleep_time).await;
+                    tokio::time::delay_for(sleep_time).await;
                 }
             });
         }


### PR DESCRIPTION
This reverts commit 2006e372a096e3835fd58b3acd53c337d5a828c0, reversing
changes made to 0bb717d25ca20ad05a58966675b1ac4b14a43bf3.

Tokio 1.0 is not yet ready in all the affected dependencies - this will
need actix and paperclip updates, which are still not released.