### PR TITLE
Add and optional name for limits

### DIFF
--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -202,6 +202,81 @@ pub struct AsyncRateLimiter {
     prometheus_metrics: PrometheusMetrics,
 }
 
+pub struct RateLimiterBuilder {
+    storage: Box<dyn Storage>,
+    prometheus_limit_name_labels_enabled: bool,
+}
+
+impl RateLimiterBuilder {
+    pub fn new() -> Self {
+        Self {
+            storage: Box::new(InMemoryStorage::default()),
+            prometheus_limit_name_labels_enabled: false,
+        }
+    }
+
+    pub fn storage(mut self, storage: Box<dyn Storage>) -> Self {
+        self.storage = storage;
+        self
+    }
+
+    pub fn with_prometheus_limit_name_labels(mut self) -> Self {
+        self.prometheus_limit_name_labels_enabled = true;
+        self
+    }
+
+    pub fn build(self) -> RateLimiter {
+        let prometheus_metrics = if self.prometheus_limit_name_labels_enabled {
+            PrometheusMetrics::new_with_counters_by_limit_name()
+        } else {
+            PrometheusMetrics::new()
+        };
+
+        RateLimiter {
+            storage: self.storage,
+            prometheus_metrics,
+        }
+    }
+}
+
+impl Default for RateLimiterBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct AsyncRateLimiterBuilder {
+    storage: Box<dyn AsyncStorage>,
+    prometheus_limit_name_labels_enabled: bool,
+}
+
+impl AsyncRateLimiterBuilder {
+    pub fn new(storage: Box<dyn AsyncStorage>) -> Self {
+        Self {
+            storage,
+            prometheus_limit_name_labels_enabled: false,
+        }
+    }
+
+    pub fn with_prometheus_limit_name_labels(mut self) -> Self {
+        self.prometheus_limit_name_labels_enabled = true;
+        self
+    }
+
+    pub fn build(self) -> AsyncRateLimiter {
+        let prometheus_metrics = if self.prometheus_limit_name_labels_enabled {
+            PrometheusMetrics::new_with_counters_by_limit_name()
+        } else {
+            PrometheusMetrics::new()
+        };
+
+        AsyncRateLimiter {
+            storage: self.storage,
+            prometheus_metrics,
+        }
+    }
+}
+
 impl RateLimiter {
     pub fn new() -> RateLimiter {
         RateLimiter {

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -257,7 +257,8 @@ impl RateLimiter {
             match self.storage.is_within_limits(&counter, delta) {
                 Ok(within_limits) => {
                     if !within_limits {
-                        self.prometheus_metrics.incr_limited_calls(&namespace);
+                        self.prometheus_metrics
+                            .incr_limited_calls(&namespace, counter.limit().name());
                         return Ok(true);
                     }
                 }
@@ -305,7 +306,7 @@ impl RateLimiter {
             self.prometheus_metrics.incr_authorized_calls(&namespace);
             Ok(false)
         } else {
-            self.prometheus_metrics.incr_limited_calls(&namespace);
+            self.prometheus_metrics.incr_limited_calls(&namespace, None); // TODO: send limit name
             Ok(true)
         }
     }
@@ -447,7 +448,8 @@ impl AsyncRateLimiter {
             match self.storage.is_within_limits(&counter, delta).await {
                 Ok(within_limits) => {
                     if !within_limits {
-                        self.prometheus_metrics.incr_limited_calls(&namespace);
+                        self.prometheus_metrics
+                            .incr_limited_calls(&namespace, counter.limit().name());
                         return Ok(true);
                     }
                 }
@@ -497,7 +499,7 @@ impl AsyncRateLimiter {
             self.prometheus_metrics.incr_authorized_calls(&namespace);
             Ok(false)
         } else {
-            self.prometheus_metrics.incr_limited_calls(&namespace);
+            self.prometheus_metrics.incr_limited_calls(&namespace, None); // TODO: send limit name
             Ok(true)
         }
     }

--- a/limitador/src/prometheus_metrics.rs
+++ b/limitador/src/prometheus_metrics.rs
@@ -2,6 +2,7 @@ use crate::limit::Namespace;
 use prometheus::{Encoder, IntCounterVec, IntGauge, Opts, Registry, TextEncoder};
 
 const NAMESPACE_LABEL: &str = "limitador_namespace";
+const LIMIT_NAME_LABEL: &str = "limit_name";
 
 struct Metric {
     name: String,
@@ -27,14 +28,56 @@ pub struct PrometheusMetrics {
     registry: Registry,
     authorized_calls: IntCounterVec,
     limited_calls: IntCounterVec,
+    use_limit_name_label: bool,
 }
 
 impl PrometheusMetrics {
     pub fn new() -> Self {
-        let labels = vec![NAMESPACE_LABEL];
+        Self::new_with_options(false)
+    }
 
-        let authorized_calls_counter = Self::authorized_calls_counter(&labels);
-        let limited_calls_counter = Self::limited_calls_counter(&labels);
+    // Note: This is optional because for a small number of limits it should be
+    // fine, but it could become a problem when defining lots of limits. See the
+    // caution note in the Prometheus docs:
+    // https://prometheus.io/docs/practices/naming/#labels
+    pub fn new_with_counters_by_limit_name() -> Self {
+        Self::new_with_options(true)
+    }
+
+    pub fn incr_authorized_calls(&self, namespace: &Namespace) {
+        self.authorized_calls
+            .with_label_values(&[namespace.as_ref()])
+            .inc();
+    }
+
+    pub fn incr_limited_calls<'a, LN>(&self, namespace: &Namespace, limit_name: LN)
+    where
+        LN: Into<Option<&'a str>>,
+    {
+        let mut labels = vec![namespace.as_ref()];
+
+        if self.use_limit_name_label {
+            // If we have configured the metric to accept 2 labels we need to
+            // set values for them.
+            labels.push(limit_name.into().unwrap_or(""));
+        }
+
+        self.limited_calls.with_label_values(&labels).inc();
+    }
+
+    pub fn gather_metrics(&self) -> String {
+        let mut buffer = Vec::new();
+
+        TextEncoder::new()
+            .encode(&self.registry.gather(), &mut buffer)
+            .unwrap();
+
+        String::from_utf8(buffer).unwrap()
+    }
+
+    fn new_with_options(use_limit_name_label: bool) -> Self {
+        let authorized_calls_counter = Self::authorized_calls_counter();
+        let limited_calls_counter = Self::limited_calls_counter(use_limit_name_label);
         let limitador_up_gauge = Self::limitador_up_gauge();
 
         let registry = Registry::new();
@@ -57,40 +100,25 @@ impl PrometheusMetrics {
             registry,
             authorized_calls: authorized_calls_counter,
             limited_calls: limited_calls_counter,
+            use_limit_name_label,
         }
     }
 
-    pub fn incr_authorized_calls(&self, namespace: &Namespace) {
-        self.authorized_calls
-            .with_label_values(&[namespace.as_ref()])
-            .inc();
-    }
-
-    pub fn incr_limited_calls(&self, namespace: &Namespace) {
-        self.limited_calls
-            .with_label_values(&[namespace.as_ref()])
-            .inc();
-    }
-
-    pub fn gather_metrics(&self) -> String {
-        let mut buffer = Vec::new();
-
-        TextEncoder::new()
-            .encode(&self.registry.gather(), &mut buffer)
-            .unwrap();
-
-        String::from_utf8(buffer).unwrap()
-    }
-
-    fn authorized_calls_counter(labels: &[&str]) -> IntCounterVec {
+    fn authorized_calls_counter() -> IntCounterVec {
         IntCounterVec::new(
             Opts::new(&AUTHORIZED_CALLS.name, &AUTHORIZED_CALLS.description),
-            &labels,
+            &[NAMESPACE_LABEL],
         )
         .unwrap()
     }
 
-    fn limited_calls_counter(labels: &[&str]) -> IntCounterVec {
+    fn limited_calls_counter(use_limit_name_label: bool) -> IntCounterVec {
+        let mut labels = vec![NAMESPACE_LABEL];
+
+        if use_limit_name_label {
+            labels.push(LIMIT_NAME_LABEL);
+        }
+
         IntCounterVec::new(
             Opts::new(&LIMITED_CALLS.name, &LIMITED_CALLS.description),
             &labels,
@@ -129,7 +157,7 @@ mod tests {
         namespaces_with_auth_counts
             .iter()
             .for_each(|(namespace, auth_count)| {
-                assert!(metrics_output.contains(&formatted_counter(
+                assert!(metrics_output.contains(&formatted_counter_with_namespace(
                     &AUTHORIZED_CALLS.name,
                     *auth_count,
                     namespace
@@ -150,7 +178,7 @@ mod tests {
             .iter()
             .for_each(|(namespace, limited_count)| {
                 for _ in 0..*limited_count {
-                    prometheus_metrics.incr_limited_calls(namespace)
+                    prometheus_metrics.incr_limited_calls(namespace, None)
                 }
             });
 
@@ -159,7 +187,7 @@ mod tests {
         namespaces_with_limited_counts
             .iter()
             .for_each(|(namespace, limited_count)| {
-                assert!(metrics_output.contains(&formatted_counter(
+                assert!(metrics_output.contains(&formatted_counter_with_namespace(
                     &LIMITED_CALLS.name,
                     *limited_count,
                     namespace
@@ -168,15 +196,85 @@ mod tests {
     }
 
     #[test]
+    fn can_show_limited_calls_by_limit_name() {
+        let prometheus_metrics = PrometheusMetrics::new_with_counters_by_limit_name();
+
+        let limits_with_counts = [
+            (Namespace::from("some_namespace"), "Some limit", 2),
+            (Namespace::from("some_namespace"), "Another limit", 3),
+        ];
+
+        limits_with_counts
+            .iter()
+            .for_each(|(namespace, limit_name, limited_count)| {
+                for _ in 0..*limited_count {
+                    prometheus_metrics.incr_limited_calls(namespace, *limit_name)
+                }
+            });
+
+        let metrics_output = prometheus_metrics.gather_metrics();
+
+        limits_with_counts
+            .iter()
+            .for_each(|(namespace, limit_name, limited_count)| {
+                assert!(
+                    metrics_output.contains(&formatted_counter_with_namespace_and_limit(
+                        &LIMITED_CALLS.name,
+                        *limited_count,
+                        namespace,
+                        limit_name,
+                    ))
+                );
+            });
+    }
+
+    #[test]
+    fn incr_limited_calls_uses_empty_string_when_no_name() {
+        let prometheus_metrics = PrometheusMetrics::new_with_counters_by_limit_name();
+        let namespace = Namespace::from("some namespace");
+        prometheus_metrics.incr_limited_calls(&namespace, None);
+
+        let metrics_output = prometheus_metrics.gather_metrics();
+
+        assert!(
+            metrics_output.contains(&formatted_counter_with_namespace_and_limit(
+                &LIMITED_CALLS.name,
+                1,
+                &namespace,
+                "",
+            ))
+        );
+    }
+
+    #[test]
     fn shows_limitador_up_set_to_1() {
         let metrics_output = PrometheusMetrics::new().gather_metrics();
         assert!(metrics_output.contains("limitador_up 1"))
     }
 
-    fn formatted_counter(name: &str, count: i32, namespace: &Namespace) -> String {
+    fn formatted_counter_with_namespace(
+        metric_name: &str,
+        count: i32,
+        namespace: &Namespace,
+    ) -> String {
         format!(
             "{}{{limitador_namespace=\"{}\"}} {}",
-            name,
+            metric_name,
+            namespace.as_ref(),
+            count,
+        )
+    }
+
+    fn formatted_counter_with_namespace_and_limit(
+        metric_name: &str,
+        count: i32,
+        namespace: &Namespace,
+        limit_name: &str,
+    ) -> String {
+        format!(
+            "{}{{limit_name=\"{}\",limitador_namespace=\"{}\"}} {}",
+            metric_name,
+            limit_name,
             namespace.as_ref(),
             count,
         )

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -10,6 +10,11 @@ pub mod wasm;
 #[cfg(feature = "redis_storage")]
 pub mod redis;
 
+pub enum Authorization<'c> {
+    Ok,
+    Limited(&'c Counter), // First counter found over the limits
+}
+
 pub trait Storage: Sync + Send {
     fn get_namespaces(&self) -> Result<HashSet<Namespace>, StorageErr>;
     fn add_limit(&self, limit: &Limit) -> Result<(), StorageErr>;
@@ -18,11 +23,11 @@ pub trait Storage: Sync + Send {
     fn delete_limits(&self, namespace: &Namespace) -> Result<(), StorageErr>;
     fn is_within_limits(&self, counter: &Counter, delta: i64) -> Result<bool, StorageErr>;
     fn update_counter(&self, counter: &Counter, delta: i64) -> Result<(), StorageErr>;
-    fn check_and_update(
+    fn check_and_update<'c>(
         &self,
-        counters: &HashSet<&Counter>,
+        counters: &HashSet<&'c Counter>,
         delta: i64,
-    ) -> Result<bool, StorageErr>;
+    ) -> Result<Authorization<'c>, StorageErr>;
     fn get_counters(&self, namespace: &Namespace) -> Result<HashSet<Counter>, StorageErr>;
     fn clear(&self) -> Result<(), StorageErr>;
 }
@@ -36,11 +41,11 @@ pub trait AsyncStorage: Sync + Send {
     async fn delete_limits(&self, namespace: &Namespace) -> Result<(), StorageErr>;
     async fn is_within_limits(&self, counter: &Counter, delta: i64) -> Result<bool, StorageErr>;
     async fn update_counter(&self, counter: &Counter, delta: i64) -> Result<(), StorageErr>;
-    async fn check_and_update(
+    async fn check_and_update<'c>(
         &self,
-        counters: &HashSet<&Counter>,
+        counters: &HashSet<&'c Counter>,
         delta: i64,
-    ) -> Result<bool, StorageErr>;
+    ) -> Result<Authorization<'c>, StorageErr>;
     async fn get_counters(&self, namespace: &Namespace) -> Result<HashSet<Counter>, StorageErr>;
     async fn clear(&self) -> Result<(), StorageErr>;
 }

--- a/limitador/src/storage/wasm.rs
+++ b/limitador/src/storage/wasm.rs
@@ -1,6 +1,6 @@
 use crate::counter::Counter;
 use crate::limit::{Limit, Namespace};
-use crate::storage::{Storage, StorageErr};
+use crate::storage::{Authorization, Storage, StorageErr};
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::sync::RwLock;
@@ -151,17 +151,17 @@ impl Storage for WasmStorage {
         Ok(())
     }
 
-    fn check_and_update(
+    fn check_and_update<'c>(
         &self,
-        counters: &HashSet<&Counter>,
+        counters: &HashSet<&'c Counter>,
         delta: i64,
-    ) -> Result<bool, StorageErr> {
+    ) -> Result<Authorization<'c>, StorageErr> {
         // This makes the operator of check + update atomic
         let mut stored_counters = self.counters.write().unwrap();
 
         for counter in counters {
             if !self.counter_is_within_limits(counter, stored_counters.get(counter), delta) {
-                return Ok(false);
+                return Ok(Authorization::Limited(counter));
             }
         }
 
@@ -169,7 +169,7 @@ impl Storage for WasmStorage {
             self.insert_or_update_counter(&mut stored_counters, counter, delta)
         }
 
-        Ok(true)
+        Ok(Authorization::Ok)
     }
 
     fn get_counters(&self, namespace: &Namespace) -> Result<HashSet<Counter>, StorageErr> {


### PR DESCRIPTION
This is part of #22.

This PR adds an optional name attribute for Limit. It also makes some changes in the Prometheus module to be able to include a limit name as a label when reporting a limited call.

Including the limit name as a label is optional. The reason is that it should be fine if the number of limits is low. However, with a large number of limits it could be problematic (check the caution note in the [Prometheus docs](https://prometheus.io/docs/practices/naming/#labels)).

This PR only addresses the part that concerns the lib. I'll do the server part the next PR.