### PR TITLE
Add option in the server to enable using limit names in Prometheus labels

### DIFF
--- a/limitador-server/docs/configuration.md
+++ b/limitador-server/docs/configuration.md
@@ -42,6 +42,15 @@ boots.
 - Format: file path.
 
 
+## LIMIT_NAME_IN_PROMETHEUS_LABELS
+
+- Enables using limit names as labels in Prometheus metrics. This is disabled by
+default because for a few limits it should be fine, but it could become a
+problem when defining lots of limits. See the caution note in the Prometheus
+docs: https://prometheus.io/docs/practices/naming/#labels
+- Optional. Disabled by default.
+- Format: set to "1" to enable.
+
 ## REDIS_LOCAL_CACHE_ENABLED
 
 - Enables a storage implementation that uses Redis, but also caches some data in

--- a/limitador-server/docs/http_server_spec.json
+++ b/limitador-server/docs/http_server_spec.json
@@ -2,6 +2,7 @@
   "swagger": "2.0",
   "definitions": {
     "CheckAndReportInfo": {
+      "type": "object",
       "properties": {
         "delta": {
           "type": "integer",
@@ -24,12 +25,14 @@
       ]
     },
     "Counter": {
+      "type": "object",
       "properties": {
         "expires_in_seconds": {
           "type": "integer",
           "format": "int64"
         },
         "limit": {
+          "type": "object",
           "properties": {
             "conditions": {
               "type": "array",
@@ -40,6 +43,9 @@
             "max_value": {
               "type": "integer",
               "format": "int64"
+            },
+            "name": {
+              "type": "string"
             },
             "namespace": {
               "type": "string"
@@ -80,6 +86,7 @@
       ]
     },
     "Limit": {
+      "type": "object",
       "properties": {
         "conditions": {
           "type": "array",
@@ -90,6 +97,9 @@
         "max_value": {
           "type": "integer",
           "format": "int64"
+        },
+        "name": {
+          "type": "string"
         },
         "namespace": {
           "type": "string"
@@ -128,18 +138,18 @@
           "500": {
             "description": "Internal Server Error"
           }
-        }
-      },
-      "parameters": [
-        {
-          "in": "body",
-          "name": "body",
-          "required": true,
-          "schema": {
-            "$ref": "#/definitions/CheckAndReportInfo"
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckAndReportInfo"
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "/check_and_report": {
       "post": {
@@ -154,18 +164,18 @@
           "500": {
             "description": "Internal Server Error"
           }
-        }
-      },
-      "parameters": [
-        {
-          "in": "body",
-          "name": "body",
-          "required": true,
-          "schema": {
-            "$ref": "#/definitions/CheckAndReportInfo"
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckAndReportInfo"
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "/counters/{namespace}": {
       "get": {
@@ -185,16 +195,16 @@
           "500": {
             "description": "Internal Server Error"
           }
-        }
-      },
-      "parameters": [
-        {
-          "in": "path",
-          "name": "namespace",
-          "required": true,
-          "type": "string"
-        }
-      ]
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
     },
     "/limits": {
       "post": {
@@ -209,7 +219,17 @@
           "500": {
             "description": "Internal Server Error"
           }
-        }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Limit"
+            }
+          }
+        ]
       },
       "delete": {
         "responses": {
@@ -234,17 +254,7 @@
             }
           }
         ]
-      },
-      "parameters": [
-        {
-          "in": "body",
-          "name": "body",
-          "required": true,
-          "schema": {
-            "$ref": "#/definitions/Limit"
-          }
-        }
-      ]
+      }
     },
     "/limits/{namespace}": {
       "get": {
@@ -264,7 +274,15 @@
           "500": {
             "description": "Internal Server Error"
           }
-        }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "type": "string"
+          }
+        ]
       },
       "delete": {
         "responses": {
@@ -287,15 +305,7 @@
             "type": "string"
           }
         ]
-      },
-      "parameters": [
-        {
-          "in": "path",
-          "name": "namespace",
-          "required": true,
-          "type": "string"
-        }
-      ]
+      }
     },
     "/report": {
       "post": {
@@ -310,18 +320,18 @@
           "500": {
             "description": "Internal Server Error"
           }
-        }
-      },
-      "parameters": [
-        {
-          "in": "body",
-          "name": "body",
-          "required": true,
-          "schema": {
-            "$ref": "#/definitions/CheckAndReportInfo"
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckAndReportInfo"
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "/status": {
       "get": {

--- a/limitador-server/src/http_api/request_types.rs
+++ b/limitador-server/src/http_api/request_types.rs
@@ -20,6 +20,7 @@ pub struct Limit {
     namespace: String,
     max_value: i64,
     seconds: u64,
+    name: Option<String>,
     conditions: Vec<String>,
     variables: Vec<String>,
 }
@@ -30,6 +31,7 @@ impl From<&LimitadorLimit> for Limit {
             namespace: ll.namespace().as_ref().to_string(),
             max_value: ll.max_value(),
             seconds: ll.seconds(),
+            name: ll.name().map(|name| name.to_string()),
             conditions: ll.conditions().into_iter().collect(),
             variables: ll.variables().into_iter().collect(),
         }
@@ -38,13 +40,19 @@ impl From<&LimitadorLimit> for Limit {
 
 impl Into<LimitadorLimit> for Limit {
     fn into(self) -> LimitadorLimit {
-        LimitadorLimit::new(
+        let mut limitador_limit = LimitadorLimit::new(
             self.namespace.as_str(),
             self.max_value,
             self.seconds,
             self.conditions,
             self.variables,
-        )
+        );
+
+        if let Some(name) = self.name {
+            limitador_limit.set_name(name)
+        }
+
+        limitador_limit
     }
 }
 


### PR DESCRIPTION
Part of #22

This PR introduces a new env to enable using limit names in Prometheus labels. To do so, it uses the work done in the lib in the previous PR (#25)