### PR TITLE
Update references to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Limitador
 
-![Github Workflow](https://github.com/3scale/limitador/workflows/Rust/badge.svg)
+![Github Workflow](https://github.com/3scale-labs/limitador/workflows/Rust/badge.svg)
 [![docs.rs](https://docs.rs/limitador/badge.svg)](https://docs.rs/limitador)
 [![Crates.io](https://img.shields.io/crates/v/limitador)](https://crates.io/crates/limitador)
 [![Docker Repository on Quay](https://quay.io/repository/3scale/limitador/status

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.3"
 authors = ["David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 description = "Rate limiter."
-homepage = "https://github.com/3scale/limitador"
-repository = "https://github.com/3scale/limitador"
+homepage = "https://github.com/3scale-labs/limitador"
+repository = "https://github.com/3scale-labs/limitador"
 documentation = "https://docs.rs/limitador"
 edition = "2018"
 


### PR DESCRIPTION
It was moved from `3scale/limitador` to `3scale-labs/limitador`.