### PR TITLE
Fix "get_limits()" integration test

### DIFF
--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -303,7 +303,7 @@ mod test {
 
     async fn get_limits_returns_empty_if_no_limits_in_namespace(rate_limiter: &mut TestsLimiter) {
         assert!(rate_limiter
-            .get_counters("test_namespace")
+            .get_limits("test_namespace")
             .await
             .unwrap()
             .is_empty())


### PR DESCRIPTION
This PR fixes a test that was calling "get_counters()" instead of "get_limits()". As the title of the test indicates, the test should be about "get_limits". "get_counters" is tested a few lines below in the same file.