### PR TITLE
Implement From<Limit> instead of Into in the HTTP API request types

### DIFF
--- a/limitador-server/src/http_api/request_types.rs
+++ b/limitador-server/src/http_api/request_types.rs
@@ -38,17 +38,17 @@ impl From<&LimitadorLimit> for Limit {
     }
 }
 
-impl Into<LimitadorLimit> for Limit {
-    fn into(self) -> LimitadorLimit {
+impl From<Limit> for LimitadorLimit {
+    fn from(limit: Limit) -> Self {
         let mut limitador_limit = LimitadorLimit::new(
-            self.namespace.as_str(),
-            self.max_value,
-            self.seconds,
-            self.conditions,
-            self.variables,
+            limit.namespace.as_str(),
+            limit.max_value,
+            limit.seconds,
+            limit.conditions,
+            limit.variables,
         );
 
-        if let Some(name) = self.name {
+        if let Some(name) = limit.name {
             limitador_limit.set_name(name)
         }
 


### PR DESCRIPTION
This PR fixes Clippy a warning introduced in rust v1.51.0.
This is what's making #32 fail.