### PR TITLE
u32 => i64 fix

### DIFF
--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -59,11 +59,11 @@ impl RateLimitService for MyRateLimiter {
 
         let is_rate_limited_res = match &*self.limiter {
             Limiter::Blocking(limiter) => {
-                limiter.check_rate_limited_and_update(namespace, &values, hits_addend as i64)
+                limiter.check_rate_limited_and_update(namespace, &values, i64::from(hits_addend))
             }
             Limiter::Async(limiter) => {
                 limiter
-                    .check_rate_limited_and_update(namespace, &values, hits_addend as i64)
+                    .check_rate_limited_and_update(namespace, &values, i64::from(hits_addend))
                     .await
             }
         };

--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -132,9 +132,9 @@ async fn get_counters(
     match get_counters_result {
         Ok(counters) => {
             let mut resp_counters: Vec<Counter> = vec![];
-            counters.iter().for_each(|c| {
+            for c in &counters {
                 resp_counters.push(c.into());
-            });
+            }
             Ok(Json(resp_counters))
         }
         Err(_) => Err(ErrorResponse::InternalServerError),


### PR DESCRIPTION
This fixes a dangerous conversion so it becomes safe (ie. breaks compilation) in the presence of code changes that would drop significant bits.

While at it fix a `for_each()` call that is more simply written as a for loop.