### PR TITLE
Infinispan limits storage (first version)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features
 
   fmt:
     name: Rustfmt
@@ -78,7 +79,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-features -- -D warnings
 
   bench:
     name: Bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,14 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    services:
+      infinispan:
+        image: infinispan/server:11.0.9.Final
+        ports:
+          - 11222:11222
+        env:
+          USER: username
+          PASS: password
     steps:
       - uses: actions/checkout@v2
       - uses: supercharge/redis-github-action@1.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,6 +1435,7 @@ dependencies = [
  "futures",
  "infinispan",
  "lazy_static",
+ "openssl",
  "paste",
  "prometheus",
  "r2d2",
@@ -1709,9 +1710,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.33"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1728,14 +1729,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.61"
+name = "openssl-src"
+version = "111.15.0+1.1.1k"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+checksum = "b1a5f6ae2ac04393b217ea9f700cd04fa9bf3d93fae2872069f3d15d908af70a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78d1833b3838dbe990df0f1f87baf640cf6146e898166afe401839d1b001e570"
 dependencies = [
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -50,7 +50,7 @@ dependencies = [
  "base64 0.13.0",
  "bitflags",
  "brotli2",
- "bytes",
+ "bytes 0.5.6",
  "cookie",
  "copyless",
  "derive_more",
@@ -201,7 +201,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "either",
  "futures-channel",
  "futures-sink",
@@ -230,7 +230,7 @@ dependencies = [
  "actix-utils",
  "actix-web-codegen",
  "awc",
- "bytes",
+ "bytes 0.5.6",
  "derive_more",
  "encoding_rs",
  "futures-channel",
@@ -463,7 +463,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "base64 0.13.0",
- "bytes",
+ "bytes 0.5.6",
  "cfg-if 1.0.0",
  "derive_more",
  "futures-core",
@@ -588,12 +588,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
 name = "bytestring"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7c05fa5172da78a62d9949d662d2ac89d4cc7355d7b49adee5163f1fb3f363"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
 ]
 
 [[package]]
@@ -655,7 +661,7 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9417a0c314565e2abffaece67e95a8cb51f9238cd39f3764d9dfdf09e72b20c"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-util",
  "memchr",
  "pin-project-lite 0.1.11",
@@ -693,6 +699,22 @@ name = "copyless"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpuid-bool"
@@ -925,6 +947,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,7 +1152,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1172,11 +1209,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -1187,7 +1224,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -1215,7 +1252,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1231,6 +1268,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes 0.5.6",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
 ]
 
 [[package]]
@@ -1252,6 +1302,21 @@ checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "infinispan"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7902811a7297306b68a314cb9754bec7f1a3836c2048561ac5f5a2174544b5a5"
+dependencies = [
+ "base64 0.13.0",
+ "http",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1281,8 +1346,14 @@ dependencies = [
  "socket2",
  "widestring",
  "winapi 0.3.9",
- "winreg",
+ "winreg 0.6.2",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
@@ -1350,9 +1421,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "limitador"
@@ -1362,12 +1433,14 @@ dependencies = [
  "cfg-if 1.0.0",
  "criterion",
  "futures",
+ "infinispan",
  "lazy_static",
  "paste",
  "prometheus",
  "r2d2",
  "rand",
  "redis",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -1463,6 +1536,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1626,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
+name = "native-tls"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nb-connect"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1706,39 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "paperclip"
@@ -1794,6 +1928,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
 name = "plotters"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,7 +2030,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "prost-derive",
 ]
 
@@ -1900,7 +2040,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "heck",
  "itertools 0.8.2",
  "log",
@@ -1931,7 +2071,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "prost",
 ]
 
@@ -2052,7 +2192,7 @@ dependencies = [
  "arc-swap",
  "async-std",
  "async-trait",
- "bytes",
+ "bytes 0.5.6",
  "combine",
  "dtoa",
  "futures",
@@ -2109,6 +2249,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 0.5.6",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite 0.2.0",
+ "serde",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2324,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,6 +2347,29 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2219,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -2552,7 +2760,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -2582,12 +2790,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -2604,7 +2822,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.12.3",
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-util",
  "http",
@@ -2920,6 +3138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,15 +3184,27 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec-arena"
@@ -3019,6 +3258,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -3160,6 +3401,15 @@ name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p limitador/src limitador-server/src
 RUN echo "fn main() {println!(\"if you see this, the build broke\")}" > limitador/src/main.rs \
  && echo "fn main() {println!(\"if you see this, the build broke\")}" > limitador-server/src/main.rs
 
-RUN cargo build --release --target=x86_64-unknown-linux-musl
+RUN cargo build --release --target=x86_64-unknown-linux-musl --all-features
 
 # avoid downloading and compiling all the dependencies when there's a change in
 # our code.
@@ -33,7 +33,7 @@ RUN rm -f target/x86_64-unknown-linux-musl/release/deps/limitador*
 
 COPY . .
 
-RUN cargo build --release --target=x86_64-unknown-linux-musl
+RUN cargo build --release --target=x86_64-unknown-linux-musl --all-features
 
 
 # ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ or you can run tests disabling the "redis storage" feature:
 cd limitador; cargo test --no-default-features
 ```
 
+Limitador also offers experimental support for Infinispan as a storage for the
+limits and counters. It's under a feature not enabled by default. To build with it and test it:
+```bash
+cargo build --features=infinispan_storage
+cargo test --features=infinispan_storage
+```
+
 ## License
 
 [Apache 2.0 License](LICENSE)

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 # We make redis and infinispan optional to be able to compile for wasm32.
 [features]
-default = ["redis_storage", "infinispan_storage"]
+default = ["redis_storage"]
 redis_storage = ["redis", "r2d2", "tokio"]
 infinispan_storage = ["infinispan", "reqwest"]
 

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [features]
 default = ["redis_storage"]
 redis_storage = ["redis", "r2d2", "tokio"]
-infinispan_storage = ["infinispan", "reqwest"]
+infinispan_storage = ["infinispan", "reqwest", "openssl"]
 
 [dependencies]
 ttl_cache = "0.5"
@@ -32,6 +32,9 @@ r2d2 = { version = "0.8", optional = true }
 tokio = { version = "0.2", optional = true, features = ["rt-core", "macros", "time"] }
 infinispan = { version = "0.1", optional = true }
 reqwest = { version = "0.10", optional = true }
+
+# reqwest dependency. Needed here to avoid problems when compiling
+openssl = { version = "0.10.34", optional = true, features = ["vendored"] }
 
 [dev-dependencies]
 serial_test = "0.5"

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -9,10 +9,11 @@ repository = "https://github.com/3scale-labs/limitador"
 documentation = "https://docs.rs/limitador"
 edition = "2018"
 
-# We make redis optional to be able to compile for wasm32.
+# We make redis and infinispan optional to be able to compile for wasm32.
 [features]
-default = ["redis_storage"]
+default = ["redis_storage", "infinispan_storage"]
 redis_storage = ["redis", "r2d2", "tokio"]
+infinispan_storage = ["infinispan", "reqwest"]
 
 [dependencies]
 ttl_cache = "0.5"
@@ -24,13 +25,13 @@ async-trait = "0.1.41"
 cfg-if = "1.0"
 prometheus = "0.10"
 lazy_static = "1.4"
-infinispan = "0.1"
-reqwest = "0.10"
 
 # Optional dependencies
 redis = { version = "0.17", optional = true, features = ["connection-manager"] }
 r2d2 = { version = "0.8", optional = true }
 tokio = { version = "0.2", optional = true, features = ["rt-core", "macros", "time"] }
+infinispan = { version = "0.1", optional = true }
+reqwest = { version = "0.10", optional = true }
 
 [dev-dependencies]
 serial_test = "0.5"

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -24,6 +24,8 @@ async-trait = "0.1.41"
 cfg-if = "1.0"
 prometheus = "0.10"
 lazy_static = "1.4"
+infinispan = "0.1"
+reqwest = "0.10"
 
 # Optional dependencies
 redis = { version = "0.17", optional = true, features = ["connection-manager"] }

--- a/limitador/src/storage/infinispan/counters.rs
+++ b/limitador/src/storage/infinispan/counters.rs
@@ -1,0 +1,124 @@
+// Infinispan does not support counters with TTL. This module provides some
+// functions on top of the Infinispan client to be able to work with counters
+// with TTLs.
+//
+// Counters in Infinispan don't have a TTL. So to implement a counter, apart
+// from the actual counter, we need a helper key with a TTL that simply tells us
+// whether the counter is still valid.
+//
+// This is how it works in more detail: When a counter is created, apart from
+// the actual Infinispan counter, this module creates a regular entry with the
+// same name as the counter and with a TTL. The TTL is set to the duration of
+// the limit. So, for a limit of 10 requests per minute, the TTL would be a
+// minute. While the key has not expired, we know that the value of the counter
+// is valid. When the key has expired, the value of the counter no longer
+// applies.
+
+use crate::storage::infinispan::response::response_to_string;
+use infinispan::errors::InfinispanError;
+use infinispan::{request, Infinispan};
+use std::time::Duration;
+
+pub struct CounterOpts {
+    initial_value: i64,
+    ttl: Duration,
+}
+
+impl CounterOpts {
+    pub fn new(initial_value: i64, ttl: Duration) -> Self {
+        CounterOpts { initial_value, ttl }
+    }
+}
+
+pub async fn get_value(
+    infinispan: &Infinispan,
+    cache_name: impl AsRef<str>,
+    counter_key: impl AsRef<str>,
+) -> Result<Option<i64>, InfinispanError> {
+    let response = infinispan
+        .run(&request::entries::get(cache_name, &counter_key))
+        .await?;
+
+    if response.status() == 404 {
+        return Ok(None);
+    }
+
+    let response = infinispan
+        .run(&request::counters::get(&counter_key))
+        .await?;
+
+    // Note: as these operations are not atomic, the counter might have been
+    // deleted at this point. In that case, the parsing will fail.
+    return match response_to_string(response).await.parse::<i64>() {
+        Ok(val) => Ok(Some(val)),
+        Err(_) => Ok(None),
+    };
+}
+
+// Returns a bool that indicates whether the counter was created.
+//
+// The param "create_counter_opts" specifies the options used to create a
+// counter when it's needed (it has expired or was never used).
+pub async fn decrement_by(
+    infinispan: &Infinispan,
+    cache_name: impl Into<String>,
+    counter_key: impl Into<String>,
+    delta: i64,
+    create_counter_opts: &CounterOpts,
+) -> Result<bool, InfinispanError> {
+    let cache_name = cache_name.into();
+    let counter_key = counter_key.into();
+
+    let response = infinispan
+        .run(&request::entries::get(&cache_name, &counter_key))
+        .await?;
+
+    if response.status() == 404 {
+        // TODO: we could use "reset" here, but it's not implemented in the
+        // client yet. So for now, delete and create.
+        let _ = infinispan
+            .run(&request::counters::delete(&counter_key))
+            .await?;
+
+        // TODO: the type of counter and its attributes should be configurable.
+        // For now let's use "weak" counters with default attributes.
+        let _ = infinispan
+            .run(
+                &request::counters::create_weak(&counter_key)
+                    .with_value(create_counter_opts.initial_value - delta),
+            )
+            .await?;
+
+        let _ = infinispan
+            .run(
+                &request::entries::create(&cache_name, &counter_key)
+                    .with_ttl(create_counter_opts.ttl),
+            )
+            .await?;
+
+        Ok(true)
+    } else {
+        // TODO: check other errors
+        let _ = infinispan
+            .run(&request::counters::increment(&counter_key).by(-delta))
+            .await?;
+
+        Ok(false)
+    }
+}
+
+pub async fn delete(
+    infinispan: &Infinispan,
+    cache_name: impl AsRef<str>,
+    counter_key: impl AsRef<str>,
+) -> Result<(), InfinispanError> {
+    let _ = infinispan
+        .run(&request::entries::delete(cache_name, &counter_key))
+        .await?;
+
+    let _ = infinispan
+        .run(&request::counters::delete(&counter_key))
+        .await?;
+
+    Ok(())
+}

--- a/limitador/src/storage/infinispan/dist_lock.rs
+++ b/limitador/src/storage/infinispan/dist_lock.rs
@@ -1,0 +1,75 @@
+// Infinispan does not support locks in the REST API. This module adds support
+// for them with some caveats.
+//
+// We use a standard Infinispan entry to simulate a lock. When we need to
+// acquire a lock, we try to create an entry with a name that encodes the entry
+// that we want to protect. If the call to create the entry fails because it
+// already exists, it means that someone else already has the lock. To release
+// the lock, we just need to delete the entry that represents it. To avoid
+// holding the lock forever, the entry that represents the lock is created with
+// a TTL.
+//
+// Notice that this approach has an important limitation: whatever we do within
+// the lock critical section is racing against the TTL, and we cannot guarantee
+// that the section will be finished within the limit of the TTL.
+
+use crate::storage::StorageErr;
+use infinispan::errors::InfinispanError;
+use infinispan::request;
+use infinispan::Infinispan;
+use std::time::Duration;
+
+const RETRIES_INTERVAL: Duration = Duration::from_millis(100);
+const RETRIES: u64 = 20;
+const LOCK_TTL: Duration = Duration::from_secs(10);
+
+pub async fn lock(
+    infinispan: &Infinispan,
+    cache_name: impl Into<String>,
+    entry_name: impl Into<String>,
+) -> Result<(), StorageErr> {
+    let cache_name = cache_name.into();
+    let entry_name = entry_name.into();
+
+    let mut retries = 0;
+
+    loop {
+        let resp = infinispan
+            .run(
+                &request::entries::create(cache_name.clone(), lock_name(&entry_name))
+                    .with_ttl(LOCK_TTL),
+            )
+            .await?;
+
+        let could_create = resp.status().is_success();
+
+        if could_create {
+            return Ok(());
+        } else {
+            if retries >= RETRIES {
+                return Err(StorageErr {
+                    msg: "can't acquire lock".into(),
+                });
+            }
+
+            retries += 1;
+
+            tokio::time::delay_for(RETRIES_INTERVAL).await;
+        }
+    }
+}
+
+pub async fn release(
+    infinispan: &Infinispan,
+    cache_name: impl AsRef<str>,
+    entry_name: impl AsRef<str>,
+) -> Result<(), InfinispanError> {
+    let _ = infinispan
+        .run(&request::entries::delete(cache_name, lock_name(entry_name)))
+        .await?;
+    Ok(())
+}
+
+fn lock_name(entry_name: impl AsRef<str>) -> String {
+    format!("lock:{}", entry_name.as_ref())
+}

--- a/limitador/src/storage/infinispan/infinispan_storage.rs
+++ b/limitador/src/storage/infinispan/infinispan_storage.rs
@@ -1,0 +1,288 @@
+use crate::counter::Counter;
+use crate::limit::{Limit, Namespace};
+use crate::storage::infinispan::counters::CounterOpts;
+use crate::storage::infinispan::{counters, sets};
+use crate::storage::keys::*;
+use crate::storage::{AsyncStorage, Authorization, StorageErr};
+use async_trait::async_trait;
+use infinispan::errors::InfinispanError;
+use infinispan::request;
+use infinispan::Infinispan;
+use std::collections::HashSet;
+use std::time::Duration;
+
+const INFINISPAN_LIMITS_CACHE_NAME: &str = "limits";
+
+pub struct InfinispanStorage {
+    infinispan: Infinispan,
+}
+
+#[async_trait]
+impl AsyncStorage for InfinispanStorage {
+    async fn get_namespaces(&self) -> Result<HashSet<Namespace>, StorageErr> {
+        Ok(self
+            .get_set(key_for_namespaces_set())
+            .await?
+            .iter()
+            .map(|ns| Namespace::from(ns.as_ref()))
+            .collect())
+    }
+
+    async fn add_limit(&self, limit: &Limit) -> Result<(), StorageErr> {
+        let serialized_limit = serde_json::to_string(limit).unwrap();
+
+        self.add_to_set(
+            key_for_limits_of_namespace(limit.namespace()),
+            serialized_limit,
+        )
+        .await?;
+
+        self.add_to_set(
+            key_for_namespaces_set(),
+            String::from(limit.namespace().clone().as_ref()),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn get_limits(&self, namespace: &Namespace) -> Result<HashSet<Limit>, StorageErr> {
+        Ok(self
+            .get_set(&key_for_limits_of_namespace(namespace))
+            .await?
+            .iter()
+            .map(|limit_json| serde_json::from_str(limit_json).unwrap())
+            .collect())
+    }
+
+    async fn delete_limit(&self, limit: &Limit) -> Result<(), StorageErr> {
+        self.delete_counters_associated_with_limit(limit).await?;
+
+        let _ = self
+            .infinispan
+            .run(&request::entries::delete(
+                INFINISPAN_LIMITS_CACHE_NAME,
+                key_for_counters_of_limit(&limit),
+            ))
+            .await?;
+
+        let serialized_limit = serde_json::to_string(limit).unwrap();
+
+        let limits_in_namespace = self
+            .delete_from_set(
+                key_for_limits_of_namespace(limit.namespace()),
+                serialized_limit,
+            )
+            .await?;
+
+        if limits_in_namespace.is_empty() {
+            self.delete_from_set(
+                key_for_namespaces_set(),
+                String::from(limit.namespace().clone().as_ref()),
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn delete_limits(&self, namespace: &Namespace) -> Result<(), StorageErr> {
+        self.delete_counters_of_namespace(namespace).await?;
+
+        for limit in self.get_limits(namespace).await? {
+            let _ = self
+                .infinispan
+                .run(&request::entries::delete(
+                    INFINISPAN_LIMITS_CACHE_NAME,
+                    key_for_counters_of_limit(&limit),
+                ))
+                .await?;
+        }
+
+        let _ = self
+            .infinispan
+            .run(&request::entries::delete(
+                INFINISPAN_LIMITS_CACHE_NAME,
+                key_for_limits_of_namespace(namespace),
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn is_within_limits(&self, counter: &Counter, delta: i64) -> Result<bool, StorageErr> {
+        let counter_key = key_for_counter(counter);
+        let counter_val =
+            counters::get_value(&self.infinispan, INFINISPAN_LIMITS_CACHE_NAME, &counter_key)
+                .await?;
+
+        match counter_val {
+            Some(val) => Ok(val - delta >= 0),
+            None => Ok(counter.max_value() - delta >= 0),
+        }
+    }
+
+    async fn update_counter(&self, counter: &Counter, delta: i64) -> Result<(), StorageErr> {
+        let counter_key = key_for_counter(counter);
+
+        let counter_created = counters::decrement_by(
+            &self.infinispan,
+            INFINISPAN_LIMITS_CACHE_NAME,
+            &counter_key,
+            delta,
+            &CounterOpts::new(counter.max_value(), Duration::from_secs(counter.seconds())),
+        )
+        .await?;
+
+        if counter_created {
+            self.add_to_set(key_for_counters_of_limit(counter.limit()), counter_key)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn check_and_update<'c>(
+        &self,
+        counters: &HashSet<&'c Counter>,
+        delta: i64,
+    ) -> Result<Authorization<'c>, StorageErr> {
+        for counter in counters {
+            if !self.is_within_limits(counter, delta).await? {
+                return Ok(Authorization::Limited(counter));
+            }
+        }
+
+        // Update only if all are withing limits
+        for counter in counters {
+            self.update_counter(counter, delta).await?
+        }
+
+        Ok(Authorization::Ok)
+    }
+
+    async fn get_counters(&self, namespace: &Namespace) -> Result<HashSet<Counter>, StorageErr> {
+        let mut res = HashSet::new();
+
+        for limit in self.get_limits(namespace).await? {
+            for counter_key in self.counter_keys_of_limit(&limit).await? {
+                let counter_val = counters::get_value(
+                    &self.infinispan,
+                    INFINISPAN_LIMITS_CACHE_NAME,
+                    &counter_key,
+                )
+                .await?;
+
+                // If the key does not exist, it means that the counter expired,
+                // so we don't have to return it.
+                //
+                // TODO: we should delete the counter from the set of counters
+                // This does not cause any bugs, but consumes memory
+                // unnecessarily.
+
+                if let Some(val) = counter_val {
+                    let mut counter: Counter = counter_from_counter_key(&counter_key);
+                    let ttl = 0; // TODO: calculate TTL from response headers.
+                    counter.set_remaining(val);
+                    counter.set_expires_in(Duration::from_secs(ttl));
+                    res.insert(counter);
+                }
+            }
+        }
+
+        Ok(res)
+    }
+
+    async fn clear(&self) -> Result<(), StorageErr> {
+        // TODO: Flush the cache instead of deleting and re-creating. There
+        // isn't a way to do this using the infinispan client for now.
+        //
+        // TODO: delete all counters (they don't belong to any Infinispan
+        // cache). There isn't a way to do this using the client for now.
+
+        let _ = self
+            .infinispan
+            .run(&request::caches::delete(INFINISPAN_LIMITS_CACHE_NAME))
+            .await?;
+
+        let _ = self
+            .infinispan
+            .run(&request::caches::create_local(INFINISPAN_LIMITS_CACHE_NAME))
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl InfinispanStorage {
+    pub async fn new(url: &str, username: &str, password: &str) -> InfinispanStorage {
+        let infinispan = Infinispan::new(url, username, password);
+
+        // TODO: the cache type and its attributes should be configurable. For
+        // now, we use the "local" type with the default attributes.
+        //
+        // TODO: check if this recreates everything or does not do anything when
+        // it already exists.
+        let _ = infinispan
+            .run(&request::caches::create_local(INFINISPAN_LIMITS_CACHE_NAME))
+            .await
+            .unwrap();
+
+        InfinispanStorage { infinispan }
+    }
+
+    async fn delete_counters_of_namespace(&self, namespace: &Namespace) -> Result<(), StorageErr> {
+        for limit in self.get_limits(namespace).await? {
+            self.delete_counters_associated_with_limit(&limit).await?
+        }
+
+        Ok(())
+    }
+
+    async fn delete_counters_associated_with_limit(&self, limit: &Limit) -> Result<(), StorageErr> {
+        for counter_key in self.counter_keys_of_limit(&limit).await? {
+            counters::delete(&self.infinispan, INFINISPAN_LIMITS_CACHE_NAME, &counter_key).await?
+        }
+
+        Ok(())
+    }
+
+    async fn counter_keys_of_limit(
+        &self,
+        limit: &Limit,
+    ) -> Result<HashSet<String>, InfinispanError> {
+        self.get_set(key_for_counters_of_limit(&limit)).await
+    }
+
+    async fn get_set(&self, set_key: impl AsRef<str>) -> Result<HashSet<String>, InfinispanError> {
+        sets::get(&self.infinispan, INFINISPAN_LIMITS_CACHE_NAME, set_key).await
+    }
+
+    async fn add_to_set(
+        &self,
+        set_key: impl Into<String>,
+        element: impl Into<String>,
+    ) -> Result<(), StorageErr> {
+        sets::add(
+            &self.infinispan,
+            INFINISPAN_LIMITS_CACHE_NAME,
+            set_key,
+            element,
+        )
+        .await
+    }
+
+    async fn delete_from_set(
+        &self,
+        set_key: impl Into<String>,
+        element: impl Into<String>,
+    ) -> Result<HashSet<String>, StorageErr> {
+        sets::delete(
+            &self.infinispan,
+            INFINISPAN_LIMITS_CACHE_NAME,
+            set_key,
+            element,
+        )
+        .await
+    }
+}

--- a/limitador/src/storage/infinispan/mod.rs
+++ b/limitador/src/storage/infinispan/mod.rs
@@ -1,0 +1,1 @@
+mod response;

--- a/limitador/src/storage/infinispan/mod.rs
+++ b/limitador/src/storage/infinispan/mod.rs
@@ -1,1 +1,2 @@
+mod counters;
 mod response;

--- a/limitador/src/storage/infinispan/mod.rs
+++ b/limitador/src/storage/infinispan/mod.rs
@@ -1,2 +1,3 @@
 mod counters;
+mod dist_lock;
 mod response;

--- a/limitador/src/storage/infinispan/mod.rs
+++ b/limitador/src/storage/infinispan/mod.rs
@@ -1,3 +1,4 @@
 mod counters;
 mod dist_lock;
 mod response;
+mod sets;

--- a/limitador/src/storage/infinispan/mod.rs
+++ b/limitador/src/storage/infinispan/mod.rs
@@ -1,4 +1,21 @@
 mod counters;
 mod dist_lock;
+mod infinispan_storage;
 mod response;
 mod sets;
+
+use crate::storage::StorageErr;
+use infinispan::errors::InfinispanError;
+pub use infinispan_storage::InfinispanStorage;
+
+impl From<reqwest::Error> for StorageErr {
+    fn from(e: reqwest::Error) -> Self {
+        StorageErr { msg: e.to_string() }
+    }
+}
+
+impl From<InfinispanError> for StorageErr {
+    fn from(e: InfinispanError) -> Self {
+        StorageErr { msg: e.to_string() }
+    }
+}

--- a/limitador/src/storage/infinispan/response.rs
+++ b/limitador/src/storage/infinispan/response.rs
@@ -1,0 +1,3 @@
+pub async fn response_to_string(response: reqwest::Response) -> String {
+    response.text_with_charset("utf-8").await.unwrap()
+}

--- a/limitador/src/storage/infinispan/sets.rs
+++ b/limitador/src/storage/infinispan/sets.rs
@@ -1,0 +1,114 @@
+// Infinispan does not support sets. This module provides some functions on top
+// of the Infinispan client to be able to work with sets.
+
+use crate::storage::infinispan::dist_lock;
+use crate::storage::infinispan::response::response_to_string;
+use crate::storage::StorageErr;
+use infinispan::errors::InfinispanError;
+use infinispan::{request, Infinispan};
+use serde_json::json;
+use std::collections::HashSet;
+use std::iter::FromIterator;
+
+pub async fn get(
+    infinispan: &Infinispan,
+    cache_name: impl AsRef<str>,
+    set_key: impl AsRef<str>,
+) -> Result<HashSet<String>, InfinispanError> {
+    let get_entry_response = infinispan
+        .run(&request::entries::get(cache_name, &set_key))
+        .await?;
+
+    let set = if get_entry_response.status() == 404 {
+        HashSet::new()
+    } else {
+        // TODO: handle other errors
+        serde_json::from_str(&response_to_string(get_entry_response).await).unwrap()
+    };
+
+    Ok(set)
+}
+
+// Creates the set if it does not exist.
+pub async fn add(
+    infinispan: &Infinispan,
+    cache_name: impl Into<String>,
+    set_key: impl Into<String>,
+    element: impl Into<String>,
+) -> Result<(), StorageErr> {
+    let cache_name = cache_name.into();
+    let set_key = set_key.into();
+
+    dist_lock::lock(infinispan, &cache_name, &set_key).await?;
+
+    let get_entry_response = infinispan
+        .run(&request::entries::get(&cache_name, &set_key))
+        .await?;
+
+    if get_entry_response.status() == 404 {
+        let limits_set: HashSet<String> = HashSet::from_iter(vec![element.into()]);
+
+        let _ = infinispan
+            .run(
+                &request::entries::create(&cache_name, &set_key)
+                    .with_value(json!(limits_set).to_string()),
+            )
+            .await?;
+    } else {
+        // TODO: handle other errors
+        let mut limits_set: HashSet<String> =
+            serde_json::from_str(&response_to_string(get_entry_response).await).unwrap();
+        limits_set.insert(element.into());
+
+        let _ = infinispan
+            .run(&request::entries::update(
+                &cache_name,
+                &set_key,
+                &json!(limits_set).to_string(),
+            ))
+            .await?;
+    }
+
+    dist_lock::release(infinispan, &cache_name, &set_key).await?;
+
+    Ok(())
+}
+
+pub async fn delete(
+    infinispan: &Infinispan,
+    cache_name: impl Into<String>,
+    set_key: impl Into<String>,
+    element: impl Into<String>,
+) -> Result<HashSet<String>, StorageErr> {
+    let cache_name = cache_name.into();
+    let set_key = set_key.into();
+
+    dist_lock::lock(infinispan, &cache_name, &set_key).await?;
+
+    let response = infinispan
+        .run(&request::entries::get(&cache_name, &set_key))
+        .await?;
+
+    let mut set: HashSet<String> =
+        serde_json::from_str(&response_to_string(response).await).unwrap();
+
+    set.remove(&element.into());
+
+    if set.is_empty() {
+        let _ = infinispan
+            .run(&request::entries::delete(&cache_name, &set_key))
+            .await?;
+    } else {
+        let _ = infinispan
+            .run(&request::entries::update(
+                &cache_name,
+                &set_key,
+                &json!(set).to_string(),
+            ))
+            .await?;
+    }
+
+    dist_lock::release(infinispan, &cache_name, &set_key).await?;
+
+    Ok(HashSet::new())
+}

--- a/limitador/src/storage/keys.rs
+++ b/limitador/src/storage/keys.rs
@@ -8,6 +8,10 @@
 // into account. Ref: https://redis.io/topics/cluster-spec (key hash tags).
 // Reminder: in format!(), "{" is escaped with "{{".
 
+// Note: keep in mind that what's described above is the default in Redis, when
+// reusing this module for other storage implementations make sure that using
+// "{}" for sharding applies.
+
 use crate::counter::Counter;
 use crate::limit::{Limit, Namespace};
 

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -10,6 +10,8 @@ pub mod wasm;
 #[cfg(feature = "redis_storage")]
 pub mod redis;
 
+mod keys;
+
 pub enum Authorization<'c> {
     Ok,
     Limited(&'c Counter), // First counter found over the limits

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -10,6 +10,7 @@ pub mod wasm;
 #[cfg(feature = "redis_storage")]
 pub mod redis;
 
+#[cfg(feature = "infinispan_storage")]
 pub mod infinispan;
 
 mod keys;

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -10,6 +10,8 @@ pub mod wasm;
 #[cfg(feature = "redis_storage")]
 pub mod redis;
 
+pub mod infinispan;
+
 mod keys;
 
 pub enum Authorization<'c> {

--- a/limitador/src/storage/redis/mod.rs
+++ b/limitador/src/storage/redis/mod.rs
@@ -4,7 +4,6 @@ mod batcher;
 mod counters_cache;
 mod redis_async;
 mod redis_cached;
-mod redis_keys;
 mod redis_sync;
 mod scripts;
 

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -4,7 +4,7 @@ use self::redis::aio::ConnectionManager;
 use self::redis::ConnectionInfo;
 use crate::counter::Counter;
 use crate::limit::{Limit, Namespace};
-use crate::storage::redis::redis_keys::*;
+use crate::storage::keys::*;
 use crate::storage::redis::scripts::{SCRIPT_DELETE_LIMIT, SCRIPT_UPDATE_COUNTER};
 use crate::storage::{AsyncStorage, Authorization, StorageErr};
 use async_trait::async_trait;

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -1,12 +1,12 @@
 use crate::counter::Counter;
 use crate::limit::{Limit, Namespace};
+use crate::storage::keys::*;
 use crate::storage::redis::batcher::Batcher;
 use crate::storage::redis::counters_cache::{
     CountersCache, CountersCacheBuilder, DEFAULT_MAX_CACHED_COUNTERS,
     DEFAULT_MAX_TTL_CACHED_COUNTERS, DEFAULT_TTL_RATIO_CACHED_COUNTERS,
 };
 use crate::storage::redis::redis_async::AsyncRedisStorage;
-use crate::storage::redis::redis_keys::*;
 use crate::storage::redis::scripts::VALUES_AND_TTLS;
 use crate::storage::{AsyncStorage, Authorization, StorageErr};
 use async_trait::async_trait;

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -3,7 +3,7 @@ extern crate redis;
 use self::redis::{Commands, ConnectionInfo, ConnectionLike, IntoConnectionInfo, RedisError};
 use crate::counter::Counter;
 use crate::limit::{Limit, Namespace};
-use crate::storage::redis::redis_keys::*;
+use crate::storage::keys::*;
 use crate::storage::redis::scripts::{SCRIPT_DELETE_LIMIT, SCRIPT_UPDATE_COUNTER};
 use crate::storage::{Authorization, Storage, StorageErr};
 use r2d2::{ManageConnection, Pool};

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -45,6 +45,7 @@ macro_rules! test_with_all_storage_impls {
                 $function(&mut TestsLimiter::new_from_async_impl(rate_limiter)).await;
             }
 
+            #[cfg(feature = "infinispan_storage")]
             #[tokio::test]
             #[serial]
             async fn [<$function _with_infinispan>]() {
@@ -80,6 +81,12 @@ mod test {
         }
     }
 
+    cfg_if::cfg_if! {
+       if #[cfg(feature = "infinispan_storage")] {
+           use limitador::storage::infinispan::InfinispanStorage;
+       }
+    }
+
     use self::limitador::counter::Counter;
     use self::limitador::storage::wasm::Clock;
     use self::limitador::RateLimiter;
@@ -87,7 +94,6 @@ mod test {
     use limitador::limit::Limit;
     use limitador::limit::Namespace;
     use limitador::storage::in_memory::InMemoryStorage;
-    use limitador::storage::infinispan::InfinispanStorage;
     use limitador::storage::wasm::WasmStorage;
     use std::collections::{HashMap, HashSet};
     use std::thread::sleep;

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -44,6 +44,19 @@ macro_rules! test_with_all_storage_impls {
                 AsyncRedisStorage::new("redis://127.0.0.1:6379").await.clear().await.unwrap();
                 $function(&mut TestsLimiter::new_from_async_impl(rate_limiter)).await;
             }
+
+            #[tokio::test]
+            #[serial]
+            async fn [<$function _with_infinispan>]() {
+                let storage = InfinispanStorage::new(
+                    "http://127.0.0.1:11222", "username", "password"
+                ).await;
+                storage.clear().await.unwrap();
+                let rate_limiter = AsyncRateLimiter::new_with_storage(
+                    Box::new(storage)
+                );
+                $function(&mut TestsLimiter::new_from_async_impl(rate_limiter)).await;
+            }
         }
     };
 }
@@ -74,6 +87,7 @@ mod test {
     use limitador::limit::Limit;
     use limitador::limit::Namespace;
     use limitador::storage::in_memory::InMemoryStorage;
+    use limitador::storage::infinispan::InfinispanStorage;
     use limitador::storage::wasm::WasmStorage;
     use std::collections::{HashMap, HashSet};
     use std::thread::sleep;


### PR DESCRIPTION
This PR adds a limits storage implementation based on [Infinispan](https://infinispan.org/). It passes all the integration tests.

Infinispan does not support directly a few data types that we need, so I had to implement them with what Infinispan offers. Those data types are:
- Counters with TTLs.
- Sets.
- Locks (take a look at the limitations I documented in the code).

I added support for each of those in separate commits.

Notice that some of the operations are not very performant. Because of the lack of support in Infinispan, we need to serialize some things, make multiple requests for some operations, etc, but I think it should be fine for a first version.

Also, there are some things that could be improved if we added some supported operations in the infinispan rust client. For example a "reset" function for counters. I've left those improvements in TODOs.

Proper error handling is missing in some places, but I think it should be fine for a first version. I've also documented this in TODOs.
