### PR TITLE
Server: allow to select Infinispan as the storage for the limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,9 +1464,11 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_yaml",
+ "thiserror",
  "tokio",
  "tonic",
  "tonic-build",
+ "url",
 ]
 
 [[package]]

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -10,12 +10,14 @@ edition = "2018"
 [dependencies]
 limitador = { path = "../limitador", features = ['infinispan_storage'] }
 tokio = { version = "0.2", features = ["full"] }
+thiserror = "1.0"
 tonic = "0.3"
 prost = "0.6"
 prost-types = "0.6"
 serde_yaml = "0.8"
 log = "0.4"
 env_logger = "0.8"
+url = "2.2"
 actix-web = "3"
 actix-rt = "1"
 paperclip = { version = "0.5", features = ["actix"] }

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-limitador = { path = "../limitador" }
+limitador = { path = "../limitador", features = ['infinispan_storage'] }
 tokio = { version = "0.2", features = ["full"] }
 tonic = "0.3"
 prost = "0.6"

--- a/limitador-server/docs/configuration.md
+++ b/limitador-server/docs/configuration.md
@@ -31,6 +31,15 @@ variables:
 - Format: integer.
 
 
+## INFINISPAN_URL
+
+- Infinispan URL. Required only when you want to use Infinispan to store the
+  limits.
+- Optional. By default, Limitador stores the limits in memory and does not
+  require Infinispan.
+- Format: URL like `http://username:password@127.0.0.1:11222`.
+
+
 ## LIMITS_FILE
 
 - YAML file that contains the limits to create when limitador boots. If the
@@ -117,7 +126,7 @@ when "REDIS_LOCAL_CACHE_ENABLED" == 1.
 
 ## REDIS_URL
 
-- Redis URL. Required only when you want to use a Redis to store the limits.
+- Redis URL. Required only when you want to use Redis to store the limits.
 - Optional. By default, Limitador stores the limits in memory and does not
 require Redis.
 - Format: URL like "redis://127.0.0.1:6379".

--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -185,7 +185,7 @@ mod tests {
     #[tokio::test]
     async fn test_returns_ok_when_no_limits_apply() {
         // No limits saved
-        let rate_limiter = MyRateLimiter::new(Arc::new(Limiter::new().await));
+        let rate_limiter = MyRateLimiter::new(Arc::new(Limiter::new().await.unwrap()));
 
         let req = RateLimitRequest {
             domain: "test_namespace".to_string(),
@@ -212,7 +212,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_returns_unknown_when_domain_is_empty() {
-        let rate_limiter = MyRateLimiter::new(Arc::new(Limiter::new().await));
+        let rate_limiter = MyRateLimiter::new(Arc::new(Limiter::new().await.unwrap()));
 
         let req = RateLimitRequest {
             domain: "".to_string(),

--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -279,7 +279,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_metrics() {
-        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await);
+        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
         let mut app = test::init_service(
             App::new()
@@ -299,7 +299,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_limits_create_read_delete() {
-        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await);
+        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
         let mut app = test::init_service(
             App::new()
@@ -357,7 +357,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_create_limit_with_name() {
-        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await);
+        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
         let mut app = test::init_service(
             App::new()
@@ -396,7 +396,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_delete_all_limits_of_namespace() {
-        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await);
+        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
         let mut app = test::init_service(
             App::new()
@@ -456,7 +456,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_check_and_report() {
-        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await);
+        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
         let mut app = test::init_service(
             App::new()
@@ -517,7 +517,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_check_and_report_endpoints_separately() {
-        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await);
+        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
         let mut app = test::init_service(
             App::new()


### PR DESCRIPTION
~This PR includes the commits from #38, so that one should be merged first. That's why I'm creating this one as a draft.~

This PR continues the work started in #38 . This PR uses the code introduced in the lib in #38 to allow users to select infinispan as the storage for the limits/counters when running the server. To do that, users simply need to set the `INFINISPAN_URL` env.