### PR TITLE
Fix clippy warning introduced in rust 1.52

### DIFF
--- a/limitador/src/storage/redis/counters_cache.rs
+++ b/limitador/src/storage/redis/counters_cache.rs
@@ -59,10 +59,7 @@ impl CountersCacheBuilder {
 
 impl CountersCache {
     pub fn get(&self, counter: &Counter) -> Option<i64> {
-        match self.cache.get(counter) {
-            Some(val) => Some(*val),
-            None => None,
-        }
+        self.cache.get(counter).copied()
     }
 
     pub fn insert(


### PR DESCRIPTION
This PR fixes a new warning introduced in the new version of clippy