### PR TITLE
Allow to choose an Infinispan cache for the limits instead of creating one

### DIFF
--- a/limitador-server/docs/configuration.md
+++ b/limitador-server/docs/configuration.md
@@ -31,6 +31,16 @@ variables:
 - Format: integer.
 
 
+## INFINISPAN_CACHE_NAME
+
+- The name of the Infinispan cache that Limitador will use to store limits and
+counters. This variable applies only when [INFINISPAN_URL](#infinispan_url) is
+set.
+- Optional. By default, Limitador creates a cache called "limitador" and
+configured as "local".
+- Format: string.
+
+
 ## INFINISPAN_URL
 
 - Infinispan URL. Required only when you want to use Infinispan to store the

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -4,7 +4,7 @@ extern crate log;
 use crate::envoy_rls::server::run_envoy_rls_server;
 use crate::http_api::server::run_http_server;
 use limitador::limit::Limit;
-use limitador::storage::infinispan::InfinispanStorage;
+use limitador::storage::infinispan::InfinispanStorageBuilder;
 use limitador::storage::redis::{AsyncRedisStorage, CachedRedisStorage, CachedRedisStorageBuilder};
 use limitador::storage::AsyncStorage;
 use limitador::{AsyncRateLimiter, AsyncRateLimiterBuilder, RateLimiter, RateLimiterBuilder};
@@ -129,7 +129,7 @@ impl Limiter {
     async fn infinispan_limiter(url: &str) -> Limiter {
         let parsed_url = Url::parse(url).unwrap();
         let storage = Box::new(
-            InfinispanStorage::new(
+            InfinispanStorageBuilder::new(
                 &format!(
                     "{}://{}:{}",
                     parsed_url.scheme(),
@@ -139,6 +139,7 @@ impl Limiter {
                 parsed_url.username(),
                 parsed_url.password().unwrap_or_default(),
             )
+            .build()
             .await,
         );
         let mut rate_limiter_builder = AsyncRateLimiterBuilder::new(storage);

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -21,6 +21,7 @@ const LIMITS_FILE_ENV: &str = "LIMITS_FILE";
 const LIMIT_NAME_IN_PROMETHEUS_LABELS_ENV: &str = "LIMIT_NAME_IN_PROMETHEUS_LABELS";
 const REDIS_URL_ENV: &str = "REDIS_URL";
 const INFINISPAN_URL_ENV: &str = "INFINISPAN_URL";
+const INFINISPAN_CACHE_NAME_ENV: &str = "INFINISPAN_CACHE_NAME";
 const DEFAULT_HOST: &str = "0.0.0.0";
 const DEFAULT_HTTP_API_PORT: u32 = 8080;
 const DEFAULT_ENVOY_RLS_PORT: u32 = 8081;
@@ -128,21 +129,24 @@ impl Limiter {
 
     async fn infinispan_limiter(url: &str) -> Limiter {
         let parsed_url = Url::parse(url).unwrap();
-        let storage = Box::new(
-            InfinispanStorageBuilder::new(
-                &format!(
-                    "{}://{}:{}",
-                    parsed_url.scheme(),
-                    parsed_url.host_str().unwrap(),
-                    parsed_url.port().unwrap().to_string(),
-                ),
-                parsed_url.username(),
-                parsed_url.password().unwrap_or_default(),
-            )
-            .build()
-            .await,
+
+        let builder = InfinispanStorageBuilder::new(
+            &format!(
+                "{}://{}:{}",
+                parsed_url.scheme(),
+                parsed_url.host_str().unwrap(),
+                parsed_url.port().unwrap().to_string(),
+            ),
+            parsed_url.username(),
+            parsed_url.password().unwrap_or_default(),
         );
-        let mut rate_limiter_builder = AsyncRateLimiterBuilder::new(storage);
+
+        let storage = match env::var(INFINISPAN_CACHE_NAME_ENV) {
+            Ok(cache_name) => builder.cache_name(cache_name).build().await,
+            Err(_) => builder.build().await,
+        };
+
+        let mut rate_limiter_builder = AsyncRateLimiterBuilder::new(Box::new(storage));
 
         if Self::env_option_is_enabled(LIMIT_NAME_IN_PROMETHEUS_LABELS_ENV) {
             rate_limiter_builder = rate_limiter_builder.with_prometheus_limit_name_labels()

--- a/limitador/src/storage/infinispan/mod.rs
+++ b/limitador/src/storage/infinispan/mod.rs
@@ -7,6 +7,7 @@ mod sets;
 use crate::storage::StorageErr;
 use infinispan::errors::InfinispanError;
 pub use infinispan_storage::InfinispanStorage;
+pub use infinispan_storage::InfinispanStorageBuilder;
 
 impl From<reqwest::Error> for StorageErr {
     fn from(e: reqwest::Error) -> Self {

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -49,9 +49,9 @@ macro_rules! test_with_all_storage_impls {
             #[tokio::test]
             #[serial]
             async fn [<$function _with_infinispan>]() {
-                let storage = InfinispanStorage::new(
+                let storage = InfinispanStorageBuilder::new(
                     "http://127.0.0.1:11222", "username", "password"
-                ).await;
+                ).build().await;
                 storage.clear().await.unwrap();
                 let rate_limiter = AsyncRateLimiter::new_with_storage(
                     Box::new(storage)
@@ -83,7 +83,7 @@ mod test {
 
     cfg_if::cfg_if! {
        if #[cfg(feature = "infinispan_storage")] {
-           use limitador::storage::infinispan::InfinispanStorage;
+           use limitador::storage::infinispan::InfinispanStorageBuilder;
        }
     }
 


### PR DESCRIPTION
This PR makes changes both in the lib and the server to allow users to choose the Infinispan cache that they'd like to use. In the server side there's a new ENV, `INFINISPAN_CACHE_NAME` for this. In the lib, I added a new builder for the `InfinispanStorage` struct that accepts a cache name.