### PR TITLE
Infinispan: make counters consistency configurable

### DIFF
--- a/limitador-server/docs/configuration.md
+++ b/limitador-server/docs/configuration.md
@@ -41,6 +41,14 @@ configured as "local".
 - Format: string.
 
 
+## INFINISPAN_COUNTERS_CONSISTENCY
+
+- Defines the consistency mode for the Infinispan counters created by Limitador.
+This variable applies only when [INFINISPAN_URL](#infinispan_url) is set.
+- Optional. Defaults to "strong".
+- Format: "strong" or "weak".
+
+
 ## INFINISPAN_URL
 
 - Infinispan URL. Required only when you want to use Infinispan to store the

--- a/limitador/src/storage/infinispan/mod.rs
+++ b/limitador/src/storage/infinispan/mod.rs
@@ -5,6 +5,7 @@ mod response;
 mod sets;
 
 use crate::storage::StorageErr;
+pub use counters::Consistency;
 use infinispan::errors::InfinispanError;
 pub use infinispan_storage::InfinispanStorage;
 pub use infinispan_storage::InfinispanStorageBuilder;


### PR DESCRIPTION
This PR allows the users of the lib and the service to choose the consistency mode they want for the Infinispan counters created by Limitador. It can be "weak" or "strong". (Ref: [Infinispan counters doc](https://infinispan.org/docs/stable/titles/rest/rest.html#rest_v2_counters))